### PR TITLE
Upgrade to Avalonia 12

### DIFF
--- a/src/SmartCommander/App.axaml.cs
+++ b/src/SmartCommander/App.axaml.cs
@@ -120,9 +120,9 @@ namespace SmartCommander
             {                
                 if (desktop != null && desktop.MainWindow != null)
                 {
-                    OptionsModel.Instance.Left = desktop.MainWindow.Bounds.Left;
+                    OptionsModel.Instance.Left = desktop.MainWindow.Position.X;
+                    OptionsModel.Instance.Top = desktop.MainWindow.Position.Y;
                     OptionsModel.Instance.Width = desktop.MainWindow.Bounds.Width;
-                    OptionsModel.Instance.Top = desktop.MainWindow.Bounds.Top;
                     OptionsModel.Instance.Height = desktop.MainWindow.Bounds.Height;
                     OptionsModel.Instance.IsMaximized = desktop.MainWindow.WindowState == WindowState.Maximized;
                 }

--- a/src/SmartCommander/Program.cs
+++ b/src/SmartCommander/Program.cs
@@ -54,7 +54,7 @@ namespace SmartCommander
             => AppBuilder.Configure<App>()
                 .UsePlatformDetect()
                 .LogToTrace()
-                .UseReactiveUI();
+                .UseReactiveUI(_ => { });
 
       
     }

--- a/src/SmartCommander/SmartCommander.csproj
+++ b/src/SmartCommander/SmartCommander.csproj
@@ -41,21 +41,18 @@
     <TrimmableAssembly Include="Avalonia.Themes.Default" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.3.11" />
-    <PackageReference Include="Avalonia.AvaloniaEdit" Version="11.3.0" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.3.11" />
-    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.9" />
-    <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.11" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.11" />
-    <PackageReference Include="MessageBox.Avalonia" Version="3.3.1.1" />
+    <PackageReference Include="Avalonia" Version="12.0.5" />
+    <PackageReference Include="Avalonia.AvaloniaEdit" Version="12.0.0" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.0.5" />
+    <PackageReference Include="Avalonia.Controls.DataGrid" Version="12.0.1" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.5" />
+    <PackageReference Include="MessageBox.Avalonia" Version="12.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="ReactiveUI.Avalonia" Version="11.3.8" />
+    <PackageReference Include="ReactiveUI.Avalonia" Version="12.0.3" />
     <PackageReference Include="Serilog" Version="4.3.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageReference Include="Xaml.Behaviors.Avalonia" Version="11.3.9.3" />  
-    <PackageReference Include="Tmds.DBus.Protocol" Version="0.21.3" />
+    <PackageReference Include="Xaml.Behaviors.Avalonia" Version="12.0.0.1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Assets\Resources.Designer.cs">

--- a/src/SmartCommander/Views/CopyMoveWindow.axaml
+++ b/src/SmartCommander/Views/CopyMoveWindow.axaml
@@ -1,5 +1,6 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:CompileBindings="False"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="200"

--- a/src/SmartCommander/Views/FileSearchWindow.axaml
+++ b/src/SmartCommander/Views/FileSearchWindow.axaml
@@ -1,5 +1,6 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:CompileBindings="False"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d" d:DesignWidth="500" d:DesignHeight="350"

--- a/src/SmartCommander/Views/FilesPane.axaml
+++ b/src/SmartCommander/Views/FilesPane.axaml
@@ -1,5 +1,6 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:CompileBindings="False"
              xmlns:vm="using:SmartCommander.ViewModels"
              xmlns:converter="using:SmartCommander.Converters"
              xmlns:i="using:Avalonia.Xaml.Interactivity"

--- a/src/SmartCommander/Views/FilesPane.axaml.cs
+++ b/src/SmartCommander/Views/FilesPane.axaml.cs
@@ -38,7 +38,8 @@ namespace SmartCommander.Views
                                 try 
                                 {
                                     IntPtr hwnd = IntPtr.Zero;
-                                    if (topLevel.PlatformImpl is Avalonia.Platform.IPlatformHandle platformHandle)
+                                    var platformHandle = topLevel.TryGetPlatformHandle();
+                                    if (platformHandle != null)
                                     {
                                         hwnd = platformHandle.Handle;
                                     }

--- a/src/SmartCommander/Views/MainWindow.axaml
+++ b/src/SmartCommander/Views/MainWindow.axaml
@@ -1,5 +1,6 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:CompileBindings="False"
         xmlns:vm="using:SmartCommander.ViewModels"
 		xmlns:views="using:SmartCommander.Views"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/src/SmartCommander/Views/MainWindow.axaml.cs
+++ b/src/SmartCommander/Views/MainWindow.axaml.cs
@@ -1,3 +1,4 @@
+using Avalonia;
 using Avalonia.Controls;
 using ReactiveUI.Avalonia;
 using MsBox.Avalonia.Enums;
@@ -107,7 +108,9 @@ namespace SmartCommander.Views
                 else
                 {
                     WindowState = WindowState.Normal;                    
-                    this.Arrange(new Avalonia.Rect(OptionsModel.Instance.Left, OptionsModel.Instance.Top, OptionsModel.Instance.Width, OptionsModel.Instance.Height));
+                    Position = new PixelPoint((int)OptionsModel.Instance.Left, (int)OptionsModel.Instance.Top);
+                    Width = OptionsModel.Instance.Width;
+                    Height = OptionsModel.Instance.Height;
                 }
             }
 

--- a/src/SmartCommander/Views/OptionsWindow.axaml
+++ b/src/SmartCommander/Views/OptionsWindow.axaml
@@ -1,5 +1,6 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:CompileBindings="False"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="400"

--- a/src/SmartCommander/Views/ProgressWindow.axaml
+++ b/src/SmartCommander/Views/ProgressWindow.axaml
@@ -1,5 +1,6 @@
 <Window xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:CompileBindings="False"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d" d:DesignWidth="400" d:DesignHeight="150"

--- a/src/SmartCommander/Views/ViewerWindow.axaml
+++ b/src/SmartCommander/Views/ViewerWindow.axaml
@@ -1,5 +1,6 @@
 <Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:CompileBindings="False"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"


### PR DESCRIPTION
Key changes:
- Bumped all Avalonia packages to 12.0.5 (AvaloniaEdit 12.0.0, ReactiveUI.Avalonia 12.0.3, MessageBox.Avalonia 12.0.0, Xaml.Behaviors.Avalonia 12.0.0.1)
- Removed Avalonia.Diagnostics (folded into core) and explicit Tmds.DBus.Protocol pin
- Added x:CompileBindings="False" to all 7 AXAML files (Avalonia 12 changed the default)
- Fixed UseReactiveUI() signature (_ => { } lambda now required)
- Replaced removed PlatformImpl HWND access with TryGetPlatformHandle()
- Replaced Window.Arrange() with Position + Width/Height; fixed latent bug where window position was never saved correctly

Closes https://github.com/anovik/SmartCommander/issues/117