### PR TITLE
Split IFileSystemService into per-backend IFileSystemProvider/composite

### DIFF
--- a/src/SmartCommander.Tests/LocalFileSystemProviderTests.cs
+++ b/src/SmartCommander.Tests/LocalFileSystemProviderTests.cs
@@ -8,12 +8,12 @@ using Xunit;
 
 namespace SmartCommander.Tests
 {
-    public class LocalFileSystemServiceTests : IDisposable
+    public class LocalFileSystemProviderTests : IDisposable
     {
         private readonly string _root;
-        private readonly LocalFileSystemService _fs = new();
+        private readonly LocalFileSystemProvider _fs = new();
 
-        public LocalFileSystemServiceTests()
+        public LocalFileSystemProviderTests()
         {
             _root = Path.Combine(Path.GetTempPath(), "SCTests_" + Guid.NewGuid().ToString("N"));
             Directory.CreateDirectory(_root);
@@ -48,7 +48,7 @@ namespace SmartCommander.Tests
             TempDir("sub2");
             TempFile("file.txt");
 
-            var dirs = await _fs.GetDirectoriesAsync(_root, new EnumerationOptions(), CancellationToken.None);
+            var dirs = await _fs.GetDirectoriesAsync(_root, new DirectoryListingFilter(), CancellationToken.None);
 
             Assert.Equal(2, dirs.Count);
             Assert.Contains(dirs, d => d.EndsWith("sub1"));
@@ -62,11 +62,93 @@ namespace SmartCommander.Tests
             TempFile("b.txt");
             TempDir("adir");
 
-            var files = await _fs.GetFilesAsync(_root, new EnumerationOptions(), CancellationToken.None);
+            var files = await _fs.GetFilesAsync(_root, new DirectoryListingFilter(), CancellationToken.None);
 
             Assert.Equal(2, files.Count);
             Assert.Contains(files, f => f.EndsWith("a.txt"));
             Assert.Contains(files, f => f.EndsWith("b.txt"));
+        }
+
+        [Fact]
+        public async Task GetFilesAsync_HiddenFile_RespectsIncludeHiddenFilter()
+        {
+            TempFile("visible.txt");
+            var hidden = TempFile(".hidden.txt");
+            if (OperatingSystem.IsWindows())
+            {
+                File.SetAttributes(hidden, File.GetAttributes(hidden) | FileAttributes.Hidden);
+            }
+
+            var withoutHidden = await _fs.GetFilesAsync(_root, new DirectoryListingFilter(), CancellationToken.None);
+            var withHidden = await _fs.GetFilesAsync(_root, new DirectoryListingFilter(IncludeHidden: true), CancellationToken.None);
+
+            Assert.DoesNotContain(withoutHidden, f => f.EndsWith(".hidden.txt"));
+            Assert.Contains(withHidden, f => f.EndsWith(".hidden.txt"));
+            Assert.Contains(withoutHidden, f => f.EndsWith("visible.txt"));
+        }
+
+        [Fact]
+        public async Task DirectoryExistsAsync_ReflectsExistence()
+        {
+            var dir = TempDir("existing");
+
+            Assert.True(await _fs.DirectoryExistsAsync(dir));
+            Assert.False(await _fs.DirectoryExistsAsync(Path.Combine(_root, "missing")));
+        }
+
+        [Fact]
+        public async Task GetDirectoryParentAsync_ReturnsParentPath()
+        {
+            var dir = TempDir("child");
+
+            var parent = await _fs.GetDirectoryParentAsync(dir);
+
+            Assert.Equal(_root, parent);
+        }
+
+        [Fact]
+        public async Task GetPathRootAsync_ReturnsRoot()
+        {
+            var root = await _fs.GetPathRootAsync(_root);
+
+            Assert.Equal(Path.GetPathRoot(_root), root);
+        }
+
+        [Fact]
+        public async Task RenameAsync_RenamesFile()
+        {
+            var src = TempFile("old_name.txt", "data");
+            var dest = Path.Combine(_root, "new_name.txt");
+
+            await _fs.RenameAsync(src, dest, isFolder: false);
+
+            Assert.False(File.Exists(src));
+            Assert.Equal("data", File.ReadAllText(dest));
+        }
+
+        [Fact]
+        public async Task RenameAsync_RenamesFolderWithContents()
+        {
+            var src = TempDir("old_dir");
+            File.WriteAllText(Path.Combine(src, "inner.txt"), "x");
+            var dest = Path.Combine(_root, "new_dir");
+
+            await _fs.RenameAsync(src, dest, isFolder: true);
+
+            Assert.False(Directory.Exists(src));
+            Assert.True(File.Exists(Path.Combine(dest, "inner.txt")));
+        }
+
+        [Fact]
+        public async Task RenameAsync_TargetExists_Throws()
+        {
+            var src = TempFile("rename_src.txt", "src");
+            var dest = TempFile("rename_dest.txt", "dest");
+
+            await Assert.ThrowsAsync<IOException>(() => _fs.RenameAsync(src, dest, isFolder: false));
+
+            Assert.Equal("src", File.ReadAllText(src));
+            Assert.Equal("dest", File.ReadAllText(dest));
         }
 
         [Fact]

--- a/src/SmartCommander/App.axaml.cs
+++ b/src/SmartCommander/App.axaml.cs
@@ -29,7 +29,7 @@ namespace SmartCommander
         {
             if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
             {
-                vm = new MainWindowViewModel(new LocalFileSystemService());
+                vm = new MainWindowViewModel(new FileSystemService(new LocalFileSystemProvider()));
                 mainWindow = new MainWindow
                 {
                     DataContext = vm,

--- a/src/SmartCommander/Services/DirectoryListingFilter.cs
+++ b/src/SmartCommander/Services/DirectoryListingFilter.cs
@@ -1,0 +1,6 @@
+namespace SmartCommander.Services
+{
+    // Backend-agnostic listing options; each provider translates them to whatever
+    // its backend understands.
+    public sealed record DirectoryListingFilter(bool IncludeHidden = false, bool Recursive = false);
+}

--- a/src/SmartCommander/Services/FileSystemService.cs
+++ b/src/SmartCommander/Services/FileSystemService.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SmartCommander.Services
+{
+    // Composite the ViewModels talk to: dispatches each call to the provider that
+    // owns the path. Only the local provider exists so far.
+    public class FileSystemService : IFileSystemService
+    {
+        private readonly IFileSystemProvider _local;
+
+        public FileSystemService(IFileSystemProvider local)
+        {
+            _local = local;
+        }
+
+        public Task<IReadOnlyList<string>> GetDirectoriesAsync(string path, DirectoryListingFilter filter, CancellationToken ct) =>
+            _local.GetDirectoriesAsync(path, filter, ct);
+
+        public Task<IReadOnlyList<string>> GetFilesAsync(string path, DirectoryListingFilter filter, CancellationToken ct) =>
+            _local.GetFilesAsync(path, filter, ct);
+
+        public Task<bool> DirectoryExistsAsync(string path, CancellationToken ct = default) =>
+            _local.DirectoryExistsAsync(path, ct);
+
+        public Task<string?> GetDirectoryParentAsync(string path, CancellationToken ct = default) =>
+            _local.GetDirectoryParentAsync(path, ct);
+
+        public Task<string?> GetPathRootAsync(string path, CancellationToken ct = default) =>
+            _local.GetPathRootAsync(path, ct);
+
+        public Task<long> GetFileSizeAsync(string path) =>
+            _local.GetFileSizeAsync(path);
+
+        public Task<DateTime> GetCreationTimeAsync(string path) =>
+            _local.GetCreationTimeAsync(path);
+
+        public Task<long> GetTotalSizeAsync(IReadOnlyList<(string FullName, bool IsFolder)> items) =>
+            _local.GetTotalSizeAsync(items);
+
+        public Task MoveFileAsync(string source, string dest) =>
+            _local.MoveFileAsync(source, dest);
+
+        public Task MoveDirectoryAsync(string source, string dest) =>
+            _local.MoveDirectoryAsync(source, dest);
+
+        public Task RenameAsync(string oldPath, string newPath, bool isFolder) =>
+            _local.RenameAsync(oldPath, newPath, isFolder);
+
+        public Task CreateDirectoryAsync(string path) =>
+            _local.CreateDirectoryAsync(path);
+
+        public Task DeleteFileAsync(string path) =>
+            _local.DeleteFileAsync(path);
+
+        public Task DeleteDirectoryAsync(string path, CancellationToken ct = default) =>
+            _local.DeleteDirectoryAsync(path, ct);
+
+        public Task<long> CopyFileAsync(string source, string dest, bool delete, bool overwrite,
+                                        IProgress<int>? progress, long processedSize, long totalSize,
+                                        CancellationToken ct) =>
+            _local.CopyFileAsync(source, dest, delete, overwrite, progress, processedSize, totalSize, ct);
+
+        public Task<long> CopyDirectoryAsync(string source, string dest, bool recursive, bool delete, bool overwrite,
+                                             IProgress<int>? progress, long processedSize, long totalSize,
+                                             CancellationToken ct) =>
+            _local.CopyDirectoryAsync(source, dest, recursive, delete, overwrite, progress, processedSize, totalSize, ct);
+
+        public Task SearchAsync(string folder, string pattern, bool topOnly, bool searchContent,
+                                string contentText, IProgress<string> results,
+                                IProgress<string>? statusProgress, CancellationToken ct) =>
+            _local.SearchAsync(folder, pattern, topOnly, searchContent, contentText, results, statusProgress, ct);
+
+        public Task<List<string>> GetDuplicatesAsync(IReadOnlyList<(string FullName, bool IsFolder)> items, string destPath) =>
+            _local.GetDuplicatesAsync(items, destPath);
+
+        public Task<List<string>> GetNonEmptyFoldersAsync(IReadOnlyList<(string FullName, bool IsFolder)> items) =>
+            _local.GetNonEmptyFoldersAsync(items);
+    }
+}

--- a/src/SmartCommander/Services/IFileSystemProvider.cs
+++ b/src/SmartCommander/Services/IFileSystemProvider.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SmartCommander.Services
+{
+    // Per-backend filesystem contract. Nothing here may take or expose a type that only
+    // makes sense for local disks, and existence/path checks are async because a remote
+    // backend answers them over a socket.
+    public interface IFileSystemProvider
+    {
+        // Listing and checks
+        Task<IReadOnlyList<string>> GetDirectoriesAsync(string path, DirectoryListingFilter filter, CancellationToken ct);
+        Task<IReadOnlyList<string>> GetFilesAsync(string path, DirectoryListingFilter filter, CancellationToken ct);
+        Task<bool> DirectoryExistsAsync(string path, CancellationToken ct = default);
+        Task<string?> GetDirectoryParentAsync(string path, CancellationToken ct = default);
+        Task<string?> GetPathRootAsync(string path, CancellationToken ct = default);
+
+        // Metadata — intended to be called from a background thread; no Task.Run internally
+        Task<long> GetFileSizeAsync(string path);
+        Task<DateTime> GetCreationTimeAsync(string path);
+        Task<long> GetTotalSizeAsync(IReadOnlyList<(string FullName, bool IsFolder)> items);
+
+        // Mutating
+        Task MoveFileAsync(string source, string dest);
+        Task MoveDirectoryAsync(string source, string dest);
+        Task RenameAsync(string oldPath, string newPath, bool isFolder);
+        Task CreateDirectoryAsync(string path);
+        Task DeleteFileAsync(string path);
+        Task DeleteDirectoryAsync(string path, CancellationToken ct = default);
+
+        // Copy/move — returns updated processedSize for progress tracking across multiple items
+        Task<long> CopyFileAsync(string source, string dest, bool delete, bool overwrite,
+                                 IProgress<int>? progress, long processedSize, long totalSize,
+                                 CancellationToken ct);
+        Task<long> CopyDirectoryAsync(string source, string dest, bool recursive, bool delete, bool overwrite,
+                                      IProgress<int>? progress, long processedSize, long totalSize,
+                                      CancellationToken ct);
+
+        // Search — results and current-folder status each streamed via separate IProgress<string>
+        Task SearchAsync(string folder, string pattern, bool topOnly, bool searchContent,
+                         string contentText, IProgress<string> results,
+                         IProgress<string>? statusProgress, CancellationToken ct);
+
+        // Bulk helpers
+        Task<List<string>> GetDuplicatesAsync(IReadOnlyList<(string FullName, bool IsFolder)> items, string destPath);
+        Task<List<string>> GetNonEmptyFoldersAsync(IReadOnlyList<(string FullName, bool IsFolder)> items);
+    }
+}

--- a/src/SmartCommander/Services/IFileSystemService.cs
+++ b/src/SmartCommander/Services/IFileSystemService.cs
@@ -1,47 +1,9 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace SmartCommander.Services
 {
-    public interface IFileSystemService
+    // The single service ViewModels depend on. Same contract as IFileSystemProvider; the
+    // implementing composite (FileSystemService) routes each call to the provider that
+    // owns the path, so ViewModels stay unaware of which backend a path belongs to.
+    public interface IFileSystemService : IFileSystemProvider
     {
-        // Listing and checks
-        Task<IReadOnlyList<string>> GetDirectoriesAsync(string path, EnumerationOptions options, CancellationToken ct);
-        Task<IReadOnlyList<string>> GetFilesAsync(string path, EnumerationOptions options, CancellationToken ct);
-        bool DirectoryExists(string path);
-        string? GetDirectoryParent(string path);
-        string? GetPathRoot(string path);
-
-        // Metadata — intended to be called from a background thread; no Task.Run internally
-        Task<long> GetFileSizeAsync(string path);
-        Task<DateTime> GetCreationTimeAsync(string path);
-        Task<long> GetTotalSizeAsync(IReadOnlyList<(string FullName, bool IsFolder)> items);
-
-        // Mutating
-        Task MoveFileAsync(string source, string dest);
-        Task MoveDirectoryAsync(string source, string dest);
-        Task CreateDirectoryAsync(string path);
-        Task DeleteFileAsync(string path);
-        Task DeleteDirectoryAsync(string path, CancellationToken ct = default);
-
-        // Copy/move — returns updated processedSize for progress tracking across multiple items
-        Task<long> CopyFileAsync(string source, string dest, bool delete, bool overwrite,
-                                 IProgress<int>? progress, long processedSize, long totalSize,
-                                 CancellationToken ct);
-        Task<long> CopyDirectoryAsync(string source, string dest, bool recursive, bool delete, bool overwrite,
-                                      IProgress<int>? progress, long processedSize, long totalSize,
-                                      CancellationToken ct);
-
-        // Search — results and current-folder status each streamed via separate IProgress<string>
-        Task SearchAsync(string folder, string pattern, bool topOnly, bool searchContent,
-                         string contentText, IProgress<string> results,
-                         IProgress<string>? statusProgress, CancellationToken ct);
-
-        // Bulk helpers
-        Task<List<string>> GetDuplicatesAsync(IReadOnlyList<(string FullName, bool IsFolder)> items, string destPath);
-        Task<List<string>> GetNonEmptyFoldersAsync(IReadOnlyList<(string FullName, bool IsFolder)> items);
     }
 }

--- a/src/SmartCommander/Services/LocalFileSystemProvider.cs
+++ b/src/SmartCommander/Services/LocalFileSystemProvider.cs
@@ -9,25 +9,38 @@ using System.Threading.Tasks;
 
 namespace SmartCommander.Services
 {
-    public class LocalFileSystemService : IFileSystemService
+    public class LocalFileSystemProvider : IFileSystemProvider
     {
-        public Task<IReadOnlyList<string>> GetDirectoriesAsync(string path, EnumerationOptions options, CancellationToken ct)
+        public Task<IReadOnlyList<string>> GetDirectoriesAsync(string path, DirectoryListingFilter filter, CancellationToken ct)
         {
             return Task.Run<IReadOnlyList<string>>(
-                () => Directory.EnumerateDirectories(path, "*", options).ToList(), ct);
+                () => Directory.EnumerateDirectories(path, "*", ToEnumerationOptions(filter)).ToList(), ct);
         }
 
-        public Task<IReadOnlyList<string>> GetFilesAsync(string path, EnumerationOptions options, CancellationToken ct)
+        public Task<IReadOnlyList<string>> GetFilesAsync(string path, DirectoryListingFilter filter, CancellationToken ct)
         {
             return Task.Run<IReadOnlyList<string>>(
-                () => Directory.EnumerateFiles(path, "*", options).ToList(), ct);
+                () => Directory.EnumerateFiles(path, "*", ToEnumerationOptions(filter)).ToList(), ct);
         }
 
-        public bool DirectoryExists(string path) => Directory.Exists(path);
+        private static EnumerationOptions ToEnumerationOptions(DirectoryListingFilter filter) => new()
+        {
+            AttributesToSkip = filter.IncludeHidden ? 0 : FileAttributes.Hidden | FileAttributes.System,
+            IgnoreInaccessible = true,
+            RecurseSubdirectories = filter.Recursive,
+        };
 
-        public string? GetDirectoryParent(string path) => Directory.GetParent(path)?.FullName;
+        // Async despite being cheap locally: Directory.Exists can stall on an unreachable
+        // network share, and remote providers answer over a socket.
+        public Task<bool> DirectoryExistsAsync(string path, CancellationToken ct = default) =>
+            Task.Run(() => Directory.Exists(path), ct);
 
-        public string? GetPathRoot(string path) => Path.GetPathRoot(Path.GetFullPath(path));
+        // Pure path math, no disk I/O — completes synchronously.
+        public Task<string?> GetDirectoryParentAsync(string path, CancellationToken ct = default) =>
+            Task.FromResult(Directory.GetParent(path)?.FullName);
+
+        public Task<string?> GetPathRootAsync(string path, CancellationToken ct = default) =>
+            Task.FromResult(Path.GetPathRoot(Path.GetFullPath(path)));
 
         public Task<long> GetFileSizeAsync(string path) =>
             Task.FromResult(new FileInfo(path).Length);
@@ -43,6 +56,19 @@ namespace SmartCommander.Services
 
         public Task MoveDirectoryAsync(string source, string dest) =>
             Task.Run(() => Directory.Move(source, dest));
+
+        public Task RenameAsync(string oldPath, string newPath, bool isFolder) =>
+            Task.Run(() =>
+            {
+                if (isFolder)
+                {
+                    Directory.Move(oldPath, newPath);
+                }
+                else
+                {
+                    File.Move(oldPath, newPath);
+                }
+            });
 
         public Task CreateDirectoryAsync(string path) =>
             Task.Run(() => Directory.CreateDirectory(path));

--- a/src/SmartCommander/ViewModels/FileViewModel.cs
+++ b/src/SmartCommander/ViewModels/FileViewModel.cs
@@ -14,6 +14,9 @@ namespace SmartCommander.ViewModels
     {
         private string _name = "";
         private string _diskFullName = "";
+        // Set only by CreateAsync; null for the ".." entry and other sync-constructed
+        // instances, which the DataGrid never lets the user rename.
+        private IFileSystemService? _fs;
         public static readonly List<string> ImageExtensions = ["jpg", "jpeg", "jpe", "bmp", "tiff", "gif", "png"];
         public static readonly List<string> VideoExtensions = ["mp4", "mov", "avi", "wmv"];
         public static readonly List<string> ArchiveExtensions = ["zip", "rar", "7z"];
@@ -97,32 +100,27 @@ namespace SmartCommander.ViewModels
                 this.RaisePropertyChanged(nameof(Name));
                 this.RaisePropertyChanged(nameof(FullName));
 
-                _ = Task.Run(async () =>
+                _ = RenameOnDiskAsync(oldName, oldFullName, destination);
+            }
+        }
+
+        private async Task RenameOnDiskAsync(string oldName, string oldFullName, string destination)
+        {
+            try
+            {
+                await _fs!.RenameAsync(oldFullName, destination, IsFolder);
+                _diskFullName = destination;
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Rename failed: {FullName}", oldFullName);
+                _diskFullName = oldFullName;
+                await Dispatcher.UIThread.InvokeAsync(() =>
                 {
-                    try
-                    {
-                        if (IsFolder)
-                        {
-                            Directory.Move(oldFullName, destination);
-                        }
-                        else
-                        {
-                            File.Move(oldFullName, destination);
-                        }
-                        _diskFullName = destination;
-                    }
-                    catch (Exception ex)
-                    {
-                        Log.Error(ex, "Rename failed: {FullName}", oldFullName);
-                        _diskFullName = oldFullName;
-                        await Dispatcher.UIThread.InvokeAsync(() =>
-                        {
-                            _name = oldName;
-                            FullName = oldFullName;
-                            this.RaisePropertyChanged(nameof(Name));
-                            this.RaisePropertyChanged(nameof(FullName));
-                        });
-                    }
+                    _name = oldName;
+                    FullName = oldFullName;
+                    this.RaisePropertyChanged(nameof(Name));
+                    this.RaisePropertyChanged(nameof(FullName));
                 });
             }
         }
@@ -143,6 +141,7 @@ namespace SmartCommander.ViewModels
                 FullName = fullName,
                 _diskFullName = fullName,
                 IsFolder = isFolder,
+                _fs = fs,
             };
 
             if (isFolder)

--- a/src/SmartCommander/ViewModels/FilesPaneViewModel.cs
+++ b/src/SmartCommander/ViewModels/FilesPaneViewModel.cs
@@ -282,7 +282,7 @@ namespace SmartCommander.ViewModels
                 if (source != null &&
                     (source.TemplatedParent is DataGridCell || source.Parent is DataGridCell))
                 {
-                    ProcessCurrentItem();
+                    _ = ProcessCurrentItem();
                 }
             }
         }
@@ -554,7 +554,7 @@ namespace SmartCommander.ViewModels
         public async Task CreateNewFolder(string name)
         {
             string newFolder = Path.Combine(CurrentDirectory, name);
-            if (_fs.DirectoryExists(newFolder))
+            if (await _fs.DirectoryExistsAsync(newFolder))
             {
                 MessageBox_Show(null, Resources.FolderExists, Resources.Alert, ButtonEnum.Ok);
                 return;
@@ -562,7 +562,7 @@ namespace SmartCommander.ViewModels
             await _fs.CreateDirectoryAsync(newFolder);
         }
 
-        public void ProcessCurrentItem(bool goToParent = false)
+        public async Task ProcessCurrentItem(bool goToParent = false)
         {
             if (CurrentItem == null)
             {
@@ -571,7 +571,7 @@ namespace SmartCommander.ViewModels
 
             if (goToParent)
             {
-                var parentPath = _fs.GetDirectoryParent(CurrentDirectory);
+                var parentPath = await _fs.GetDirectoryParentAsync(CurrentDirectory);
                 if (parentPath == null)
                 {
                     return;
@@ -585,7 +585,7 @@ namespace SmartCommander.ViewModels
             {
                 if (CurrentItem.FullName == "..")
                 {
-                    var parentPath = _fs.GetDirectoryParent(CurrentDirectory);
+                    var parentPath = await _fs.GetDirectoryParentAsync(CurrentDirectory);
                     _pendingRestoreItemName = Path.GetFileName(CurrentDirectory);
                     CurrentDirectory = parentPath ?? CurrentDirectory;
                 }
@@ -596,13 +596,23 @@ namespace SmartCommander.ViewModels
             }
             else
             {
-                new Process
+                // Callers discard the returned task, so a launch failure (e.g. no
+                // application associated with the file) must be surfaced here.
+                try
                 {
-                    StartInfo = new ProcessStartInfo(CurrentItem.FullName)
+                    new Process
                     {
-                        UseShellExecute = true
-                    }
-                }.Start();
+                        StartInfo = new ProcessStartInfo(CurrentItem.FullName)
+                        {
+                            UseShellExecute = true
+                        }
+                    }.Start();
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, "Failed to open {FullName}", CurrentItem.FullName);
+                    MessageBox_Show(null, ex.Message, Resources.Alert, ButtonEnum.Ok);
+                }
             }
         }
 
@@ -615,28 +625,39 @@ namespace SmartCommander.ViewModels
             var sortingBy = Sorting;
             var ascending = Ascending;
 
-            if (!_fs.DirectoryExists(dir) || !Path.IsPathFullyQualified(dir))
+            bool isParent;
+            string? selectedDrive;
+            try
+            {
+                if (!await _fs.DirectoryExistsAsync(dir, cts.Token) || !Path.IsPathFullyQualified(dir))
+                {
+                    return;
+                }
+                // Re-checked before any further cts.Token read: a newer load may have
+                // cancelled and disposed this cts while the exists-check was in flight,
+                // and a disposed source throws from its Token property.
+                if (cts != _loadCts)
+                {
+                    return;
+                }
+                isParent = await _fs.GetDirectoryParentAsync(dir, cts.Token) != null;
+                selectedDrive = OperatingSystem.IsWindows() ? await _fs.GetPathRootAsync(dir, cts.Token) : null;
+            }
+            catch (OperationCanceledException)
             {
                 return;
             }
 
-            bool isParent = _fs.GetDirectoryParent(dir) != null;
-            string? selectedDrive = OperatingSystem.IsWindows() ? _fs.GetPathRoot(dir) : null;
-
-            var options = new EnumerationOptions
-            {
-                AttributesToSkip = OptionsModel.Instance.IsHiddenSystemFilesDisplayed
-                    ? 0 : FileAttributes.Hidden | FileAttributes.System,
-                IgnoreInaccessible = true,
-                RecurseSubdirectories = false,
-            };
+            var filter = new DirectoryListingFilter(
+                IncludeHidden: OptionsModel.Instance.IsHiddenSystemFilesDisplayed,
+                Recursive: false);
 
             IReadOnlyList<string> dirPaths;
             IReadOnlyList<string> filePaths;
             try
             {
-                var dirsTask = _fs.GetDirectoriesAsync(dir, options, cts.Token);
-                var filesTask = _fs.GetFilesAsync(dir, options, cts.Token);
+                var dirsTask = _fs.GetDirectoriesAsync(dir, filter, cts.Token);
+                var filesTask = _fs.GetFilesAsync(dir, filter, cts.Token);
                 await Task.WhenAll(dirsTask, filesTask);
                 dirPaths = dirsTask.Result;
                 filePaths = filesTask.Result;
@@ -820,23 +841,37 @@ namespace SmartCommander.ViewModels
         string? SelectedDrive
         {
             get { return _selectedDrive; }
-            set
+            set { _ = SetSelectedDriveAsync(value); }
+        }
+
+        // Fire-and-forget from the setter (a TwoWay binding can only call a sync setter);
+        // starts on the UI thread and every await resumes there.
+        private async Task SetSelectedDriveAsync(string? value)
+        {
+            // If the pane navigated while the exists-check was in flight (slow network
+            // drive, out-of-order combo picks), this selection no longer reflects the
+            // user's latest intent — abandon it instead of navigating or alerting late.
+            var directoryAtStart = CurrentDirectory;
+
+            bool exists = value != null && await _fs.DirectoryExistsAsync(value);
+            if (CurrentDirectory != directoryAtStart)
             {
-                if (value == null || !_fs.DirectoryExists(value))
-                {
-                    MessageBox_Show(null, Resources.DriveNotAvailable, Resources.Alert, ButtonEnum.Ok);
-                    return;
-                }
-
-                var driveFromDirectory = _fs.GetPathRoot(CurrentDirectory);
-
-                _selectedDrive = value;
-                if (_selectedDrive != driveFromDirectory)
-                {
-                    CurrentDirectory = _selectedDrive!;
-                }
-                this.RaisePropertyChanged(nameof(SelectedDrive));
+                return;
             }
+            if (!exists)
+            {
+                MessageBox_Show(null, Resources.DriveNotAvailable, Resources.Alert, ButtonEnum.Ok);
+                return;
+            }
+
+            var driveFromDirectory = await _fs.GetPathRootAsync(CurrentDirectory);
+
+            _selectedDrive = value;
+            if (_selectedDrive != driveFromDirectory)
+            {
+                CurrentDirectory = _selectedDrive!;
+            }
+            this.RaisePropertyChanged(nameof(SelectedDrive));
         }
     }
 }

--- a/src/SmartCommander/ViewModels/MainWindowViewModel.cs
+++ b/src/SmartCommander/ViewModels/MainWindowViewModel.cs
@@ -594,9 +594,11 @@ namespace SmartCommander.ViewModels
         public async Task<bool> PasteFiles(string destDirectory, List<string> sourcePaths, bool isCut,
             Func<Task>? onMoveCompleted = null)
         {
-            var items = await Task.Run(() => sourcePaths
-                .Select(p => (FullName: p, IsFolder: _fs.DirectoryExists(p)))
-                .ToList());
+            var items = new List<(string FullName, bool IsFolder)>();
+            foreach (var path in sourcePaths)
+            {
+                items.Add((path, await _fs.DirectoryExistsAsync(path)));
+            }
             if (items.Count == 0)
             {
                 return false;
@@ -722,10 +724,10 @@ namespace SmartCommander.ViewModels
                         if (move)
                         {
                             bool sameDrive = string.Equals(
-                                _fs.GetPathRoot(fullName),
-                                _fs.GetPathRoot(destDirectory),
+                                await _fs.GetPathRootAsync(fullName, ct),
+                                await _fs.GetPathRootAsync(destDirectory, ct),
                                 OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
-                            if (sameDrive && !_fs.DirectoryExists(destFolder))
+                            if (sameDrive && !await _fs.DirectoryExistsAsync(destFolder, ct))
                             {
                                 await _fs.MoveDirectoryAsync(fullName, destFolder);
                             }

--- a/src/SmartCommander/Views/FilesPane.axaml.cs
+++ b/src/SmartCommander/Views/FilesPane.axaml.cs
@@ -133,12 +133,12 @@ namespace SmartCommander.Views
                 var viewModel = DataContext as FilesPaneViewModel;
                 if (e.Key == Key.Back)
                 {
-                    viewModel?.ProcessCurrentItem(true);
+                    _ = viewModel?.ProcessCurrentItem(true);
                 }
 
                 if (e.Key == Key.Enter)
                 {
-                    viewModel?.ProcessCurrentItem();
+                    _ = viewModel?.ProcessCurrentItem();
                 }
             }
         }


### PR DESCRIPTION
Groundwork for FTP support: behavior-neutral for local use, no FTP code yet.

- LocalFileSystemService renamed to LocalFileSystemProvider, implementing
  the new per-backend IFileSystemProvider contract.
- IFileSystemService keeps its name as the ViewModels' dependency; the new
  FileSystemService composite implements it by delegating to the provider
  that owns the path (only the local provider so far).
- DirectoryListingFilter (IncludeHidden/Recursive) replaces
  System.IO.EnumerationOptions in listing signatures; the local provider
  translates internally.
- DirectoryExists/GetDirectoryParent/GetPathRoot are now async with
  CancellationToken, since a remote backend answers these over a socket.
  ProcessCurrentItem and the SelectedDrive setter became async as fallout.
- New RenameAsync retires FileViewModel.Name's raw File.Move/Directory.Move;
  the optimistic-update/revert-on-failure behavior is unchanged.
- Fixes from independent review: staleness guard in SetSelectedDriveAsync,
  cancellation-safe pre-guard awaits in LoadDirectoryAsync, error surfacing
  for a failed file launch in ProcessCurrentItem (previously an unhandled
  crash), FileSystemService ctor takes IFileSystemProvider.
- Tests renamed to LocalFileSystemProviderTests; new coverage for
  RenameAsync (file/folder/target-exists), the async existence and path
  checks, and the IncludeHidden filter translation.