### PR TITLE
Basic FTP operations: connect, download, upload

### DIFF
--- a/src/SmartCommander.Tests/FileSystemServiceTests.cs
+++ b/src/SmartCommander.Tests/FileSystemServiceTests.cs
@@ -7,11 +7,9 @@ using Xunit;
 
 namespace SmartCommander.Tests
 {
-    // Composite scheme-parsing and pairwise-dispatch tests. No real FTP connection is involved:
-    // the local side is a hand-written fake, and the ftp:// paths exercise the "no connection
-    // active" guard - the only FTP-provider-independent behavior the composite owns. Full FTP
-    // dispatch (an actual connection present) needs a live server, so it's covered separately
-    // by the opt-in integration tests in FtpIntegrationTests.cs.
+    // Composite scheme-parsing and pairwise-dispatch tests: a hand-written local fake plus the
+    // ftp:// "no connection active" guard. Dispatch against a real FTP connection is covered
+    // separately by the opt-in integration tests in FtpIntegrationTests.cs.
     public class FileSystemServiceTests
     {
         private const string LocalPath = @"C:\local\file.txt";

--- a/src/SmartCommander.Tests/FileSystemServiceTests.cs
+++ b/src/SmartCommander.Tests/FileSystemServiceTests.cs
@@ -1,0 +1,271 @@
+using SmartCommander.Services;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SmartCommander.Tests
+{
+    // Composite scheme-parsing and pairwise-dispatch tests. No real FTP connection is involved:
+    // the local side is a hand-written fake, and the ftp:// paths exercise the "no connection
+    // active" guard - the only FTP-provider-independent behavior the composite owns. Full FTP
+    // dispatch (an actual connection present) needs a live server, so it's covered separately
+    // by the opt-in integration tests in FtpIntegrationTests.cs.
+    public class FileSystemServiceTests
+    {
+        private const string LocalPath = @"C:\local\file.txt";
+        private const string FtpPath = "ftp:///remote/file.txt";
+
+        private sealed class FakeFileSystemProvider : IFileSystemProvider
+        {
+            public List<string> Calls { get; } = new();
+
+            public Task<IReadOnlyList<string>> GetDirectoriesAsync(string path, DirectoryListingFilter filter, CancellationToken ct)
+            {
+                Calls.Add(nameof(GetDirectoriesAsync));
+                return Task.FromResult<IReadOnlyList<string>>(new List<string>());
+            }
+
+            public Task<IReadOnlyList<string>> GetFilesAsync(string path, DirectoryListingFilter filter, CancellationToken ct)
+            {
+                Calls.Add(nameof(GetFilesAsync));
+                return Task.FromResult<IReadOnlyList<string>>(new List<string>());
+            }
+
+            public Task<bool> DirectoryExistsAsync(string path, CancellationToken ct = default)
+            {
+                Calls.Add(nameof(DirectoryExistsAsync));
+                return Task.FromResult(true);
+            }
+
+            public Task<bool> FileExistsAsync(string path, CancellationToken ct = default)
+            {
+                Calls.Add(nameof(FileExistsAsync));
+                return Task.FromResult(false);
+            }
+
+            public Task<string?> GetDirectoryParentAsync(string path, CancellationToken ct = default)
+            {
+                Calls.Add(nameof(GetDirectoryParentAsync));
+                return Task.FromResult<string?>(null);
+            }
+
+            public Task<string?> GetPathRootAsync(string path, CancellationToken ct = default)
+            {
+                Calls.Add(nameof(GetPathRootAsync));
+                return Task.FromResult<string?>(@"C:\");
+            }
+
+            public Task<long> GetFileSizeAsync(string path)
+            {
+                Calls.Add(nameof(GetFileSizeAsync));
+                return Task.FromResult(0L);
+            }
+
+            public Task<DateTime> GetCreationTimeAsync(string path)
+            {
+                Calls.Add(nameof(GetCreationTimeAsync));
+                return Task.FromResult(DateTime.MinValue);
+            }
+
+            public Task<long> GetTotalSizeAsync(IReadOnlyList<(string FullName, bool IsFolder)> items)
+            {
+                Calls.Add(nameof(GetTotalSizeAsync));
+                return Task.FromResult(0L);
+            }
+
+            public Task MoveFileAsync(string source, string dest)
+            {
+                Calls.Add(nameof(MoveFileAsync));
+                return Task.CompletedTask;
+            }
+
+            public Task MoveDirectoryAsync(string source, string dest)
+            {
+                Calls.Add(nameof(MoveDirectoryAsync));
+                return Task.CompletedTask;
+            }
+
+            public Task RenameAsync(string oldPath, string newPath, bool isFolder)
+            {
+                Calls.Add(nameof(RenameAsync));
+                return Task.CompletedTask;
+            }
+
+            public Task CreateDirectoryAsync(string path)
+            {
+                Calls.Add(nameof(CreateDirectoryAsync));
+                return Task.CompletedTask;
+            }
+
+            public Task DeleteFileAsync(string path)
+            {
+                Calls.Add(nameof(DeleteFileAsync));
+                return Task.CompletedTask;
+            }
+
+            public Task DeleteDirectoryAsync(string path, CancellationToken ct = default)
+            {
+                Calls.Add(nameof(DeleteDirectoryAsync));
+                return Task.CompletedTask;
+            }
+
+            public Task<long> CopyFileAsync(string source, string dest, bool delete, bool overwrite,
+                                            IProgress<int>? progress, long processedSize, long totalSize,
+                                            CancellationToken ct)
+            {
+                Calls.Add(nameof(CopyFileAsync));
+                return Task.FromResult(processedSize);
+            }
+
+            public Task<long> CopyDirectoryAsync(string source, string dest, bool recursive, bool delete, bool overwrite,
+                                                 IProgress<int>? progress, long processedSize, long totalSize,
+                                                 CancellationToken ct)
+            {
+                Calls.Add(nameof(CopyDirectoryAsync));
+                return Task.FromResult(processedSize);
+            }
+
+            public Task SearchAsync(string folder, string pattern, bool topOnly, bool searchContent,
+                                    string contentText, IProgress<string> results,
+                                    IProgress<string>? statusProgress, CancellationToken ct)
+            {
+                Calls.Add(nameof(SearchAsync));
+                return Task.CompletedTask;
+            }
+
+            public Task<List<string>> GetDuplicatesAsync(IReadOnlyList<(string FullName, bool IsFolder)> items, string destPath)
+            {
+                Calls.Add(nameof(GetDuplicatesAsync));
+                return Task.FromResult(new List<string>());
+            }
+
+            public Task<List<string>> GetNonEmptyFoldersAsync(IReadOnlyList<(string FullName, bool IsFolder)> items)
+            {
+                Calls.Add(nameof(GetNonEmptyFoldersAsync));
+                return Task.FromResult(new List<string>());
+            }
+        }
+
+        [Fact]
+        public void IsFtpConnected_NoConnection_IsFalse()
+        {
+            var fs = new FileSystemService(new FakeFileSystemProvider());
+            Assert.False(fs.IsFtpConnected);
+            Assert.Null(fs.FtpHost);
+        }
+
+        [Fact]
+        public async Task DisconnectFtpAsync_NoConnection_NoOps()
+        {
+            var fs = new FileSystemService(new FakeFileSystemProvider());
+            await fs.DisconnectFtpAsync();
+            Assert.False(fs.IsFtpConnected);
+        }
+
+        [Fact]
+        public async Task GetDirectoriesAsync_LocalPath_DispatchesToLocalProvider()
+        {
+            var local = new FakeFileSystemProvider();
+            var fs = new FileSystemService(local);
+
+            await fs.GetDirectoriesAsync(LocalPath, new DirectoryListingFilter(), CancellationToken.None);
+
+            Assert.Contains(nameof(FakeFileSystemProvider.GetDirectoriesAsync), local.Calls);
+        }
+
+        [Fact]
+        public async Task GetDirectoriesAsync_FtpPath_NoConnection_Throws()
+        {
+            var fs = new FileSystemService(new FakeFileSystemProvider());
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                fs.GetDirectoriesAsync(FtpPath, new DirectoryListingFilter(), CancellationToken.None));
+        }
+
+        [Fact]
+        public async Task DirectoryExistsAsync_FtpPath_NoConnection_Throws()
+        {
+            var fs = new FileSystemService(new FakeFileSystemProvider());
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() => fs.DirectoryExistsAsync(FtpPath));
+        }
+
+        [Fact]
+        public async Task CopyFileAsync_LocalToLocal_DispatchesToLocalProvider()
+        {
+            var local = new FakeFileSystemProvider();
+            var fs = new FileSystemService(local);
+
+            await fs.CopyFileAsync(LocalPath, @"C:\local\dest.txt", delete: false, overwrite: false,
+                progress: null, processedSize: 0, totalSize: 0, CancellationToken.None);
+
+            Assert.Contains(nameof(FakeFileSystemProvider.CopyFileAsync), local.Calls);
+        }
+
+        [Fact]
+        public async Task CopyFileAsync_LocalToFtp_NoConnection_Throws()
+        {
+            var fs = new FileSystemService(new FakeFileSystemProvider());
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                fs.CopyFileAsync(LocalPath, FtpPath, delete: false, overwrite: false,
+                    progress: null, processedSize: 0, totalSize: 0, CancellationToken.None));
+        }
+
+        [Fact]
+        public async Task CopyFileAsync_FtpToLocal_NoConnection_Throws()
+        {
+            var fs = new FileSystemService(new FakeFileSystemProvider());
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                fs.CopyFileAsync(FtpPath, LocalPath, delete: false, overwrite: false,
+                    progress: null, processedSize: 0, totalSize: 0, CancellationToken.None));
+        }
+
+        [Fact]
+        public async Task GetTotalSizeAsync_EmptyItems_ReturnsZeroWithoutTouchingAnyProvider()
+        {
+            var local = new FakeFileSystemProvider();
+            var fs = new FileSystemService(local);
+
+            var size = await fs.GetTotalSizeAsync(new List<(string FullName, bool IsFolder)>());
+
+            Assert.Equal(0, size);
+            Assert.Empty(local.Calls);
+        }
+
+        [Fact]
+        public async Task GetDuplicatesAsync_EmptyItems_ReturnsEmptyWithoutTouchingAnyProvider()
+        {
+            var local = new FakeFileSystemProvider();
+            var fs = new FileSystemService(local);
+
+            var duplicates = await fs.GetDuplicatesAsync(new List<(string FullName, bool IsFolder)>(), LocalPath);
+
+            Assert.Empty(duplicates);
+            Assert.Empty(local.Calls);
+        }
+
+        [Fact]
+        public async Task GetDuplicatesAsync_LocalToLocal_DispatchesToLocalProvider()
+        {
+            var local = new FakeFileSystemProvider();
+            var fs = new FileSystemService(local);
+
+            await fs.GetDuplicatesAsync(new List<(string FullName, bool IsFolder)> { (LocalPath, false) }, @"C:\local");
+
+            Assert.Contains(nameof(FakeFileSystemProvider.GetDuplicatesAsync), local.Calls);
+        }
+
+        [Fact]
+        public async Task GetDuplicatesAsync_LocalToFtp_NoConnection_Throws()
+        {
+            var fs = new FileSystemService(new FakeFileSystemProvider());
+
+            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                fs.GetDuplicatesAsync(new List<(string FullName, bool IsFolder)> { (LocalPath, false) }, FtpPath));
+        }
+    }
+}

--- a/src/SmartCommander.Tests/FtpIntegrationTests.cs
+++ b/src/SmartCommander.Tests/FtpIntegrationTests.cs
@@ -1,0 +1,207 @@
+using SmartCommander.Services;
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SmartCommander.Tests
+{
+    // Opt-in only: hits real public FTP servers, so these must stay out of the default
+    // `dotnet test` run (network-dependent, external services, inherently flaky). xUnit 2.9.3
+    // has no runtime-conditional Skip (that needs xUnit v3), so each test self-gates on an env
+    // var instead and no-ops (reports Passed, not Skipped) when it isn't set - a known,
+    // deliberate trade-off given the pinned xUnit version. Run with:
+    //   SMARTCOMMANDER_FTP_INTEGRATION_TESTS=1 dotnet test src/SmartCommander.Tests
+    public class FtpIntegrationTests
+    {
+        private static bool OptedIn =>
+            Environment.GetEnvironmentVariable("SMARTCOMMANDER_FTP_INTEGRATION_TESTS") == "1";
+
+        // Read-only public demo server (Rebex): host test.rebex.net, demo/password, /pub/example.
+        private static async Task<FtpFileSystemProvider> ConnectRebexAsync()
+        {
+            var provider = new FtpFileSystemProvider();
+            await provider.ConnectAsync("test.rebex.net", 21, "demo", "password", anonymous: false, CancellationToken.None);
+            return provider;
+        }
+
+        // Read-write public test server (dlptest.com): host ftp.dlptest.com, passive-only,
+        // uploaded files auto-delete after ~10 minutes so tests don't need to worry about buildup.
+        private static async Task<FtpFileSystemProvider> ConnectDlpTestAsync()
+        {
+            var provider = new FtpFileSystemProvider();
+            await provider.ConnectAsync("ftp.dlptest.com", 21, "dlpuser", "rNrKYTX9g7z3RgJRmxWuGHbeu",
+                anonymous: false, CancellationToken.None);
+            return provider;
+        }
+
+        [Fact]
+        public async Task Rebex_ListRootDirectory_ContainsPubFolder()
+        {
+            if (!OptedIn)
+            {
+                return;
+            }
+
+            await using var provider = await ConnectRebexAsync();
+
+            var dirs = await provider.GetDirectoriesAsync(RemotePath.Combine("/"), new DirectoryListingFilter(), CancellationToken.None);
+
+            Assert.Contains(dirs, d => d.EndsWith("/pub"));
+        }
+
+        [Fact]
+        public async Task Rebex_ListPubExample_ContainsReadme()
+        {
+            if (!OptedIn)
+            {
+                return;
+            }
+
+            await using var provider = await ConnectRebexAsync();
+
+            var files = await provider.GetFilesAsync(RemotePath.Combine("/pub/example"), new DirectoryListingFilter(), CancellationToken.None);
+
+            Assert.Contains(files, f => f.EndsWith("readme.txt"));
+        }
+
+        [Fact]
+        public async Task Rebex_DownloadReadme_ProducesNonEmptyLocalFile()
+        {
+            if (!OptedIn)
+            {
+                return;
+            }
+
+            await using var provider = await ConnectRebexAsync();
+            var localPath = Path.Combine(Path.GetTempPath(), "SCTests_rebex_" + Guid.NewGuid().ToString("N") + ".txt");
+            try
+            {
+                await provider.DownloadFileAsync(RemotePath.Combine("/pub/example/readme.txt"), localPath,
+                    delete: false, overwrite: true, progress: null, processedSize: 0, totalSize: 0, CancellationToken.None);
+
+                Assert.True(File.Exists(localPath));
+                Assert.True(new FileInfo(localPath).Length > 0);
+            }
+            finally
+            {
+                if (File.Exists(localPath))
+                {
+                    File.Delete(localPath);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task DlpTest_UploadDownloadDelete_RoundTrips()
+        {
+            if (!OptedIn)
+            {
+                return;
+            }
+
+            await using var provider = await ConnectDlpTestAsync();
+            var name = "SCTests_" + Guid.NewGuid().ToString("N") + ".txt";
+            var localSource = Path.Combine(Path.GetTempPath(), name);
+            var localDest = Path.Combine(Path.GetTempPath(), "down_" + name);
+            var remotePath = RemotePath.CombineChild(RemotePath.Combine("/"), name);
+            File.WriteAllText(localSource, "SmartCommander FTP integration test");
+
+            try
+            {
+                await provider.UploadFileAsync(localSource, remotePath, delete: false, overwrite: true,
+                    progress: null, processedSize: 0, totalSize: 0, CancellationToken.None);
+                Assert.True(await provider.FileExistsAsync(remotePath));
+
+                await provider.DownloadFileAsync(remotePath, localDest, delete: false, overwrite: true,
+                    progress: null, processedSize: 0, totalSize: 0, CancellationToken.None);
+                Assert.Equal("SmartCommander FTP integration test", File.ReadAllText(localDest));
+
+                await provider.DeleteFileAsync(remotePath);
+                Assert.False(await provider.FileExistsAsync(remotePath));
+            }
+            finally
+            {
+                if (File.Exists(localSource))
+                {
+                    File.Delete(localSource);
+                }
+                if (File.Exists(localDest))
+                {
+                    File.Delete(localDest);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task DlpTest_RenameFile_UpdatesRemoteName()
+        {
+            if (!OptedIn)
+            {
+                return;
+            }
+
+            await using var provider = await ConnectDlpTestAsync();
+            var oldName = "SCTests_" + Guid.NewGuid().ToString("N") + "_old.txt";
+            var newName = "SCTests_" + Guid.NewGuid().ToString("N") + "_new.txt";
+            var localSource = Path.Combine(Path.GetTempPath(), oldName);
+            var oldRemote = RemotePath.CombineChild(RemotePath.Combine("/"), oldName);
+            var newRemote = RemotePath.CombineChild(RemotePath.Combine("/"), newName);
+            File.WriteAllText(localSource, "rename test");
+
+            try
+            {
+                await provider.UploadFileAsync(localSource, oldRemote, delete: false, overwrite: true,
+                    progress: null, processedSize: 0, totalSize: 0, CancellationToken.None);
+
+                await provider.RenameAsync(oldRemote, newRemote, isFolder: false);
+
+                Assert.False(await provider.FileExistsAsync(oldRemote));
+                Assert.True(await provider.FileExistsAsync(newRemote));
+
+                await provider.DeleteFileAsync(newRemote);
+            }
+            finally
+            {
+                if (File.Exists(localSource))
+                {
+                    File.Delete(localSource);
+                }
+            }
+        }
+
+        [Fact]
+        public async Task DlpTest_CreateAndDeleteDirectory_RoundTrips()
+        {
+            if (!OptedIn)
+            {
+                return;
+            }
+
+            await using var provider = await ConnectDlpTestAsync();
+            var dirName = "SCTests_" + Guid.NewGuid().ToString("N");
+            var remoteDir = RemotePath.CombineChild(RemotePath.Combine("/"), dirName);
+
+            await provider.CreateDirectoryAsync(remoteDir);
+            Assert.True(await provider.DirectoryExistsAsync(remoteDir));
+
+            await provider.DeleteDirectoryAsync(remoteDir);
+            Assert.False(await provider.DirectoryExistsAsync(remoteDir));
+        }
+
+        [Fact]
+        public async Task DlpTest_FailedConnect_ThrowsWithoutSilentDisconnect()
+        {
+            if (!OptedIn)
+            {
+                return;
+            }
+
+            var provider = new FtpFileSystemProvider();
+            await Assert.ThrowsAnyAsync<Exception>(() =>
+                provider.ConnectAsync("ftp.dlptest.com", 21, "not-a-real-user", "not-a-real-password",
+                    anonymous: false, CancellationToken.None));
+        }
+    }
+}

--- a/src/SmartCommander.Tests/FtpIntegrationTests.cs
+++ b/src/SmartCommander.Tests/FtpIntegrationTests.cs
@@ -7,11 +7,8 @@ using Xunit;
 
 namespace SmartCommander.Tests
 {
-    // Opt-in only: hits real public FTP servers, so these must stay out of the default
-    // `dotnet test` run (network-dependent, external services, inherently flaky). xUnit 2.9.3
-    // has no runtime-conditional Skip (that needs xUnit v3), so each test self-gates on an env
-    // var instead and no-ops (reports Passed, not Skipped) when it isn't set - a known,
-    // deliberate trade-off given the pinned xUnit version. Run with:
+    // Opt-in only: hits real public FTP servers, so these stay out of the default `dotnet test`
+    // run. Each test self-gates on an env var and no-ops (reports Passed) when it's unset. Run with:
     //   SMARTCOMMANDER_FTP_INTEGRATION_TESTS=1 dotnet test src/SmartCommander.Tests
     public class FtpIntegrationTests
     {
@@ -188,6 +185,53 @@ namespace SmartCommander.Tests
 
             await provider.DeleteDirectoryAsync(remoteDir);
             Assert.False(await provider.DirectoryExistsAsync(remoteDir));
+        }
+
+        // Read-write public test server (dlp-test.com - note the hyphen, a distinct host from
+        // dlptest.com above): host ftp.dlp-test.com, true anonymous login (no credentials needed).
+        private static async Task<FtpFileSystemProvider> ConnectDlpTestPubAsync()
+        {
+            var provider = new FtpFileSystemProvider();
+            await provider.ConnectAsync("ftp.dlp-test.com", 21, "anonymous", "", anonymous: true, CancellationToken.None);
+            return provider;
+        }
+
+        [Fact]
+        public async Task DlpTestPub_AnonymousListUploadDelete_RoundTrips()
+        {
+            if (!OptedIn)
+            {
+                return;
+            }
+
+            await using var provider = await ConnectDlpTestPubAsync();
+            var name = "SCTests_" + Guid.NewGuid().ToString("N") + ".txt";
+            var localSource = Path.Combine(Path.GetTempPath(), name);
+            var remotePath = RemotePath.CombineChild(RemotePath.Combine("/"), name);
+            File.WriteAllText(localSource, "SmartCommander FTP anonymous integration test");
+
+            try
+            {
+                // Listing must succeed anonymously before we ever touch upload/delete.
+                var dirsBeforeUpload = await provider.GetDirectoriesAsync(RemotePath.Combine("/"), new DirectoryListingFilter(), CancellationToken.None);
+                var filesBeforeUpload = await provider.GetFilesAsync(RemotePath.Combine("/"), new DirectoryListingFilter(), CancellationToken.None);
+                Assert.NotNull(dirsBeforeUpload);
+                Assert.DoesNotContain(filesBeforeUpload, f => f.EndsWith(name));
+
+                await provider.UploadFileAsync(localSource, remotePath, delete: false, overwrite: true,
+                    progress: null, processedSize: 0, totalSize: 0, CancellationToken.None);
+                Assert.True(await provider.FileExistsAsync(remotePath));
+
+                await provider.DeleteFileAsync(remotePath);
+                Assert.False(await provider.FileExistsAsync(remotePath));
+            }
+            finally
+            {
+                if (File.Exists(localSource))
+                {
+                    File.Delete(localSource);
+                }
+            }
         }
 
         [Fact]

--- a/src/SmartCommander.Tests/FtpTransferMenuModeTests.cs
+++ b/src/SmartCommander.Tests/FtpTransferMenuModeTests.cs
@@ -1,0 +1,29 @@
+using SmartCommander.ViewModels;
+using Xunit;
+
+namespace SmartCommander.Tests
+{
+    public class FtpTransferMenuModeTests
+    {
+        [Fact]
+        public void NeitherPaneFtp_ReturnsLocalClipboard()
+        {
+            Assert.Equal(MainWindowViewModel.FtpTransferMenuMode.LocalClipboard,
+                MainWindowViewModel.DetermineFtpTransferMenuMode(paneIsFtp: false, otherPaneIsFtp: false));
+        }
+
+        [Fact]
+        public void ThisPaneFtp_ReturnsDownload()
+        {
+            Assert.Equal(MainWindowViewModel.FtpTransferMenuMode.Download,
+                MainWindowViewModel.DetermineFtpTransferMenuMode(paneIsFtp: true, otherPaneIsFtp: false));
+        }
+
+        [Fact]
+        public void OtherPaneFtp_ReturnsUpload()
+        {
+            Assert.Equal(MainWindowViewModel.FtpTransferMenuMode.Upload,
+                MainWindowViewModel.DetermineFtpTransferMenuMode(paneIsFtp: false, otherPaneIsFtp: true));
+        }
+    }
+}

--- a/src/SmartCommander.Tests/LocalFileSystemProviderTests.cs
+++ b/src/SmartCommander.Tests/LocalFileSystemProviderTests.cs
@@ -88,12 +88,36 @@ namespace SmartCommander.Tests
         }
 
         [Fact]
+        public async Task GetFilesAsync_Recursive_IncludesSubdirectoryFiles()
+        {
+            TempFile("top.txt");
+            var sub = TempDir("sub");
+            File.WriteAllText(Path.Combine(sub, "nested.txt"), "x");
+
+            var nonRecursive = await _fs.GetFilesAsync(_root, new DirectoryListingFilter(Recursive: false), CancellationToken.None);
+            var recursive = await _fs.GetFilesAsync(_root, new DirectoryListingFilter(Recursive: true), CancellationToken.None);
+
+            Assert.DoesNotContain(nonRecursive, f => f.EndsWith("nested.txt"));
+            Assert.Contains(recursive, f => f.EndsWith("nested.txt"));
+            Assert.Contains(recursive, f => f.EndsWith("top.txt"));
+        }
+
+        [Fact]
         public async Task DirectoryExistsAsync_ReflectsExistence()
         {
             var dir = TempDir("existing");
 
             Assert.True(await _fs.DirectoryExistsAsync(dir));
             Assert.False(await _fs.DirectoryExistsAsync(Path.Combine(_root, "missing")));
+        }
+
+        [Fact]
+        public async Task FileExistsAsync_ReflectsExistence()
+        {
+            var file = TempFile("existing.txt");
+
+            Assert.True(await _fs.FileExistsAsync(file));
+            Assert.False(await _fs.FileExistsAsync(Path.Combine(_root, "missing.txt")));
         }
 
         [Fact]
@@ -149,6 +173,19 @@ namespace SmartCommander.Tests
 
             Assert.Equal("src", File.ReadAllText(src));
             Assert.Equal("dest", File.ReadAllText(dest));
+        }
+
+        [Fact]
+        public async Task RenameAsync_FolderTargetExists_Throws()
+        {
+            var src = TempDir("rename_src_dir");
+            File.WriteAllText(Path.Combine(src, "inner.txt"), "x");
+            var dest = TempDir("rename_dest_dir");
+
+            await Assert.ThrowsAsync<IOException>(() => _fs.RenameAsync(src, dest, isFolder: true));
+
+            Assert.True(Directory.Exists(src));
+            Assert.True(File.Exists(Path.Combine(src, "inner.txt")));
         }
 
         [Fact]

--- a/src/SmartCommander.Tests/RemotePathTests.cs
+++ b/src/SmartCommander.Tests/RemotePathTests.cs
@@ -1,0 +1,62 @@
+using SmartCommander.Services;
+using Xunit;
+
+namespace SmartCommander.Tests
+{
+    public class RemotePathTests
+    {
+        [Theory]
+        [InlineData("ftp:///home/user", true)]
+        [InlineData("FTP:///home/user", true)]
+        [InlineData(@"C:\Users\anna", false)]
+        [InlineData("/home/user", false)]
+        public void IsFtp_DetectsScheme(string path, bool expected)
+        {
+            Assert.Equal(expected, RemotePath.IsFtp(path));
+        }
+
+        [Fact]
+        public void GetRemotePart_ReturnsPathAfterScheme()
+        {
+            Assert.Equal("/home/user", RemotePath.GetRemotePart("ftp:///home/user"));
+        }
+
+        [Fact]
+        public void GetRemotePart_AddsLeadingSlashIfMissing()
+        {
+            Assert.Equal("/home/user", RemotePath.GetRemotePart("ftp://home/user"));
+        }
+
+        [Fact]
+        public void GetRemotePart_NotFtpPath_Throws()
+        {
+            Assert.Throws<System.ArgumentException>(() => RemotePath.GetRemotePart(@"C:\Users\anna"));
+        }
+
+        [Fact]
+        public void Combine_AddsSchemeAndLeadingSlash()
+        {
+            Assert.Equal("ftp:///home/user", RemotePath.Combine("/home/user"));
+            Assert.Equal("ftp:///home/user", RemotePath.Combine("home/user"));
+        }
+
+        [Fact]
+        public void CombineChild_FtpBase_JoinsWithForwardSlash()
+        {
+            Assert.Equal("ftp:///home/user/file.txt", RemotePath.CombineChild("ftp:///home/user", "file.txt"));
+        }
+
+        [Fact]
+        public void CombineChild_FtpBaseWithTrailingSlash_DoesNotDoubleSlash()
+        {
+            Assert.Equal("ftp:///home/user/file.txt", RemotePath.CombineChild("ftp:///home/user/", "file.txt"));
+        }
+
+        [Fact]
+        public void CombineChild_LocalBase_UsesPathCombine()
+        {
+            var expected = System.IO.Path.Combine(@"C:\Users\anna", "file.txt");
+            Assert.Equal(expected, RemotePath.CombineChild(@"C:\Users\anna", "file.txt"));
+        }
+    }
+}

--- a/src/SmartCommander/Assets/Resources.Designer.cs
+++ b/src/SmartCommander/Assets/Resources.Designer.cs
@@ -1112,5 +1112,14 @@ namespace SmartCommander.Assets {
                 return ResourceManager.GetString("CantEditFtpFile", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Opening FTP files isn't supported yet.
+        /// </summary>
+        public static string CantOpenFtpFile {
+            get {
+                return ResourceManager.GetString("CantOpenFtpFile", resourceCulture);
+            }
+        }
     }
 }

--- a/src/SmartCommander/Assets/Resources.Designer.cs
+++ b/src/SmartCommander/Assets/Resources.Designer.cs
@@ -932,5 +932,113 @@ namespace SmartCommander.Assets {
                 return ResourceManager.GetString("License", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to _FTP.
+        /// </summary>
+        public static string MenuFtp {
+            get {
+                return ResourceManager.GetString("MenuFtp", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to _Connect....
+        /// </summary>
+        public static string MenuFtpConnect {
+            get {
+                return ResourceManager.GetString("MenuFtpConnect", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to _Disconnect.
+        /// </summary>
+        public static string MenuFtpDisconnect {
+            get {
+                return ResourceManager.GetString("MenuFtpDisconnect", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Connect to FTP Server.
+        /// </summary>
+        public static string FtpConnectTitle {
+            get {
+                return ResourceManager.GetString("FtpConnectTitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Saved connections:.
+        /// </summary>
+        public static string FtpSavedConnections {
+            get {
+                return ResourceManager.GetString("FtpSavedConnections", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Host:.
+        /// </summary>
+        public static string FtpHost {
+            get {
+                return ResourceManager.GetString("FtpHost", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Port:.
+        /// </summary>
+        public static string FtpPort {
+            get {
+                return ResourceManager.GetString("FtpPort", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Username:.
+        /// </summary>
+        public static string FtpUsername {
+            get {
+                return ResourceManager.GetString("FtpUsername", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Password:.
+        /// </summary>
+        public static string FtpPassword {
+            get {
+                return ResourceManager.GetString("FtpPassword", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Anonymous login.
+        /// </summary>
+        public static string FtpAnonymous {
+            get {
+                return ResourceManager.GetString("FtpAnonymous", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Connect.
+        /// </summary>
+        public static string FtpConnectButton {
+            get {
+                return ResourceManager.GetString("FtpConnectButton", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to connect to FTP server: {0}.
+        /// </summary>
+        public static string FtpConnectionFailed {
+            get {
+                return ResourceManager.GetString("FtpConnectionFailed", resourceCulture);
+            }
+        }
     }
 }

--- a/src/SmartCommander/Assets/Resources.Designer.cs
+++ b/src/SmartCommander/Assets/Resources.Designer.cs
@@ -97,7 +97,7 @@ namespace SmartCommander.Assets {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Can&apos;t copy file here.
+        ///   Looks up a localized string similar to Can&apos;t copy file here: {0}.
         /// </summary>
         public static string CantCopyFileHere {
             get {
@@ -115,7 +115,7 @@ namespace SmartCommander.Assets {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Can&apos;t copy folder here.
+        ///   Looks up a localized string similar to Can&apos;t copy folder here: {0}.
         /// </summary>
         public static string CantCopyFolderHere {
             get {
@@ -151,6 +151,24 @@ namespace SmartCommander.Assets {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Can&apos;t delete file here: {0}.
+        /// </summary>
+        public static string CantDeleteFileHere {
+            get {
+                return ResourceManager.GetString("CantDeleteFileHere", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Can&apos;t delete folder here: {0}.
+        /// </summary>
+        public static string CantDeleteFolderHere {
+            get {
+                return ResourceManager.GetString("CantDeleteFolderHere", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Can&apos;t edit the folder.
         /// </summary>
         public static string CantEditFolder {
@@ -169,7 +187,16 @@ namespace SmartCommander.Assets {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Can&apos;t move file here.
+        ///   Looks up a localized string similar to Can&apos;t load directory: {0}.
+        /// </summary>
+        public static string CantLoadDirectory {
+            get {
+                return ResourceManager.GetString("CantLoadDirectory", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Can&apos;t move file here: {0}.
         /// </summary>
         public static string CantMoveFileHere {
             get {
@@ -187,7 +214,7 @@ namespace SmartCommander.Assets {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Can&apos;t move folder here.
+        ///   Looks up a localized string similar to Can&apos;t move folder here: {0}.
         /// </summary>
         public static string CantMoveFolderHere {
             get {
@@ -1038,6 +1065,51 @@ namespace SmartCommander.Assets {
         public static string FtpConnectionFailed {
             get {
                 return ResourceManager.GetString("FtpConnectionFailed", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Download.
+        /// </summary>
+        public static string Download {
+            get {
+                return ResourceManager.GetString("Download", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Upload.
+        /// </summary>
+        public static string Upload {
+            get {
+                return ResourceManager.GetString("Upload", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Move.
+        /// </summary>
+        public static string Move {
+            get {
+                return ResourceManager.GetString("Move", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Viewing FTP files isn't supported yet.
+        /// </summary>
+        public static string CantViewFtpFile {
+            get {
+                return ResourceManager.GetString("CantViewFtpFile", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Editing FTP files isn't supported yet.
+        /// </summary>
+        public static string CantEditFtpFile {
+            get {
+                return ResourceManager.GetString("CantEditFtpFile", resourceCulture);
             }
         }
     }

--- a/src/SmartCommander/Assets/Resources.fr-FR.resx
+++ b/src/SmartCommander/Assets/Resources.fr-FR.resx
@@ -468,4 +468,7 @@
   <data name="CantEditFtpFile" xml:space="preserve">
     <value>L'édition des fichiers FTP n'est pas encore prise en charge</value>
   </data>
+  <data name="CantOpenFtpFile" xml:space="preserve">
+    <value>L'ouverture des fichiers FTP n'est pas encore prise en charge</value>
+  </data>
 </root>

--- a/src/SmartCommander/Assets/Resources.fr-FR.resx
+++ b/src/SmartCommander/Assets/Resources.fr-FR.resx
@@ -127,13 +127,13 @@
     <value>Annuler</value>
   </data>
   <data name="CantCopyFileHere" xml:space="preserve">
-    <value>Impossible de copier le fichier ici</value>
+    <value>Impossible de copier le fichier ici : {0}</value>
   </data>
   <data name="CantCopyFileToItself" xml:space="preserve">
     <value>Impossible de copier les fichiers dans le même dossier</value>
   </data>
   <data name="CantCopyFolderHere" xml:space="preserve">
-    <value>Impossible de copier le dossier ici</value>
+    <value>Impossible de copier le dossier ici : {0}</value>
   </data>
   <data name="CantCopyFolderToItself" xml:space="preserve">
     <value>Impossible de copier le dossier vers lui-même</value>
@@ -144,20 +144,29 @@
   <data name="CantCreateFolder" xml:space="preserve">
     <value>Impossible de créer le dossier</value>
   </data>
+  <data name="CantDeleteFileHere" xml:space="preserve">
+    <value>Impossible de supprimer le fichier ici : {0}</value>
+  </data>
+  <data name="CantDeleteFolderHere" xml:space="preserve">
+    <value>Impossible de supprimer le dossier ici : {0}</value>
+  </data>
   <data name="CantEditFolder" xml:space="preserve">
     <value>Impossible d'éditer le dossier</value>
   </data>
   <data name="CantExtractArchive" xml:space="preserve">
     <value>Impossible d'extraire l'archive {0}</value>
   </data>
+  <data name="CantLoadDirectory" xml:space="preserve">
+    <value>Impossible de charger le dossier : {0}</value>
+  </data>
   <data name="CantMoveFileHere" xml:space="preserve">
-    <value>Impossible de déplacer le fichier ici</value>
+    <value>Impossible de déplacer le fichier ici : {0}</value>
   </data>
   <data name="CantMoveFileToItself" xml:space="preserve">
     <value>Impossible de déplacer les fichiers dans le même dossier</value>
   </data>
   <data name="CantMoveFolderHere" xml:space="preserve">
-    <value>Impossible de déplacer le dossier ici</value>
+    <value>Impossible de déplacer le dossier ici : {0}</value>
   </data>
   <data name="CantMoveFolderToItself" xml:space="preserve">
     <value>Impossible de déplacer le dossier vers lui-même</value>
@@ -443,5 +452,20 @@
   </data>
   <data name="FtpConnectionFailed" xml:space="preserve">
     <value>Échec de la connexion au serveur FTP : {0}</value>
+  </data>
+  <data name="Download" xml:space="preserve">
+    <value>Télécharger</value>
+  </data>
+  <data name="Upload" xml:space="preserve">
+    <value>Envoyer</value>
+  </data>
+  <data name="Move" xml:space="preserve">
+    <value>Déplacer</value>
+  </data>
+  <data name="CantViewFtpFile" xml:space="preserve">
+    <value>L'affichage des fichiers FTP n'est pas encore pris en charge</value>
+  </data>
+  <data name="CantEditFtpFile" xml:space="preserve">
+    <value>L'édition des fichiers FTP n'est pas encore prise en charge</value>
   </data>
 </root>

--- a/src/SmartCommander/Assets/Resources.fr-FR.resx
+++ b/src/SmartCommander/Assets/Resources.fr-FR.resx
@@ -408,4 +408,40 @@
   <data name="License" xml:space="preserve">
     <value>Licence : GNU General Public License v3.0</value>
   </data>
+  <data name="MenuFtp" xml:space="preserve">
+    <value>_FTP</value>
+  </data>
+  <data name="MenuFtpConnect" xml:space="preserve">
+    <value>_Connecter...</value>
+  </data>
+  <data name="MenuFtpDisconnect" xml:space="preserve">
+    <value>_Déconnecter</value>
+  </data>
+  <data name="FtpConnectTitle" xml:space="preserve">
+    <value>Connexion à un serveur FTP</value>
+  </data>
+  <data name="FtpSavedConnections" xml:space="preserve">
+    <value>Connexions enregistrées :</value>
+  </data>
+  <data name="FtpHost" xml:space="preserve">
+    <value>Hôte :</value>
+  </data>
+  <data name="FtpPort" xml:space="preserve">
+    <value>Port :</value>
+  </data>
+  <data name="FtpUsername" xml:space="preserve">
+    <value>Nom d'utilisateur :</value>
+  </data>
+  <data name="FtpPassword" xml:space="preserve">
+    <value>Mot de passe :</value>
+  </data>
+  <data name="FtpAnonymous" xml:space="preserve">
+    <value>Connexion anonyme</value>
+  </data>
+  <data name="FtpConnectButton" xml:space="preserve">
+    <value>Connecter</value>
+  </data>
+  <data name="FtpConnectionFailed" xml:space="preserve">
+    <value>Échec de la connexion au serveur FTP : {0}</value>
+  </data>
 </root>

--- a/src/SmartCommander/Assets/Resources.resx
+++ b/src/SmartCommander/Assets/Resources.resx
@@ -127,13 +127,13 @@
     <value>Cancel</value>
   </data>
   <data name="CantCopyFileHere" xml:space="preserve">
-    <value>Can't copy file here</value>
+    <value>Can't copy file here: {0}</value>
   </data>
   <data name="CantCopyFileToItself" xml:space="preserve">
     <value>Can't copy files to the same directory</value>
   </data>
   <data name="CantCopyFolderHere" xml:space="preserve">
-    <value>Can't copy folder here</value>
+    <value>Can't copy folder here: {0}</value>
   </data>
   <data name="CantCopyFolderToItself" xml:space="preserve">
     <value>Can't copy folder to itself</value>
@@ -144,20 +144,29 @@
   <data name="CantCreateFolder" xml:space="preserve">
     <value>Can't create folder</value>
   </data>
+  <data name="CantDeleteFileHere" xml:space="preserve">
+    <value>Can't delete file here: {0}</value>
+  </data>
+  <data name="CantDeleteFolderHere" xml:space="preserve">
+    <value>Can't delete folder here: {0}</value>
+  </data>
   <data name="CantEditFolder" xml:space="preserve">
     <value>Can't edit the folder</value>
   </data>
   <data name="CantExtractArchive" xml:space="preserve">
     <value>Can't extract archive {0}</value>
   </data>
+  <data name="CantLoadDirectory" xml:space="preserve">
+    <value>Can't load directory: {0}</value>
+  </data>
   <data name="CantMoveFileHere" xml:space="preserve">
-    <value>Can't move file here</value>
+    <value>Can't move file here: {0}</value>
   </data>
   <data name="CantMoveFileToItself" xml:space="preserve">
     <value>Can't move files to the same directory</value>
   </data>
   <data name="CantMoveFolderHere" xml:space="preserve">
-    <value>Can't move folder here</value>
+    <value>Can't move folder here: {0}</value>
   </data>
   <data name="CantMoveFolderToItself" xml:space="preserve">
     <value>Can't move folder to itself</value>
@@ -443,5 +452,20 @@
   </data>
   <data name="FtpConnectionFailed" xml:space="preserve">
     <value>Failed to connect to FTP server: {0}</value>
+  </data>
+  <data name="Download" xml:space="preserve">
+    <value>Download</value>
+  </data>
+  <data name="Upload" xml:space="preserve">
+    <value>Upload</value>
+  </data>
+  <data name="Move" xml:space="preserve">
+    <value>Move</value>
+  </data>
+  <data name="CantViewFtpFile" xml:space="preserve">
+    <value>Viewing FTP files isn't supported yet</value>
+  </data>
+  <data name="CantEditFtpFile" xml:space="preserve">
+    <value>Editing FTP files isn't supported yet</value>
   </data>
 </root>

--- a/src/SmartCommander/Assets/Resources.resx
+++ b/src/SmartCommander/Assets/Resources.resx
@@ -408,4 +408,40 @@
   <data name="License" xml:space="preserve">
     <value>License: GNU General Public License v3.0</value>
   </data>
+  <data name="MenuFtp" xml:space="preserve">
+    <value>_FTP</value>
+  </data>
+  <data name="MenuFtpConnect" xml:space="preserve">
+    <value>_Connect...</value>
+  </data>
+  <data name="MenuFtpDisconnect" xml:space="preserve">
+    <value>_Disconnect</value>
+  </data>
+  <data name="FtpConnectTitle" xml:space="preserve">
+    <value>Connect to FTP Server</value>
+  </data>
+  <data name="FtpSavedConnections" xml:space="preserve">
+    <value>Saved connections:</value>
+  </data>
+  <data name="FtpHost" xml:space="preserve">
+    <value>Host:</value>
+  </data>
+  <data name="FtpPort" xml:space="preserve">
+    <value>Port:</value>
+  </data>
+  <data name="FtpUsername" xml:space="preserve">
+    <value>Username:</value>
+  </data>
+  <data name="FtpPassword" xml:space="preserve">
+    <value>Password:</value>
+  </data>
+  <data name="FtpAnonymous" xml:space="preserve">
+    <value>Anonymous login</value>
+  </data>
+  <data name="FtpConnectButton" xml:space="preserve">
+    <value>Connect</value>
+  </data>
+  <data name="FtpConnectionFailed" xml:space="preserve">
+    <value>Failed to connect to FTP server: {0}</value>
+  </data>
 </root>

--- a/src/SmartCommander/Assets/Resources.resx
+++ b/src/SmartCommander/Assets/Resources.resx
@@ -468,4 +468,7 @@
   <data name="CantEditFtpFile" xml:space="preserve">
     <value>Editing FTP files isn't supported yet</value>
   </data>
+  <data name="CantOpenFtpFile" xml:space="preserve">
+    <value>Opening FTP files isn't supported yet</value>
+  </data>
 </root>

--- a/src/SmartCommander/Assets/Resources.ru-RU.resx
+++ b/src/SmartCommander/Assets/Resources.ru-RU.resx
@@ -408,4 +408,40 @@
   <data name="License" xml:space="preserve">
     <value>Лицензия: GNU General Public License v3.0</value>
   </data>
+  <data name="MenuFtp" xml:space="preserve">
+    <value>_FTP</value>
+  </data>
+  <data name="MenuFtpConnect" xml:space="preserve">
+    <value>_Подключиться...</value>
+  </data>
+  <data name="MenuFtpDisconnect" xml:space="preserve">
+    <value>_Отключиться</value>
+  </data>
+  <data name="FtpConnectTitle" xml:space="preserve">
+    <value>Подключение к FTP-серверу</value>
+  </data>
+  <data name="FtpSavedConnections" xml:space="preserve">
+    <value>Сохранённые подключения:</value>
+  </data>
+  <data name="FtpHost" xml:space="preserve">
+    <value>Хост:</value>
+  </data>
+  <data name="FtpPort" xml:space="preserve">
+    <value>Порт:</value>
+  </data>
+  <data name="FtpUsername" xml:space="preserve">
+    <value>Имя пользователя:</value>
+  </data>
+  <data name="FtpPassword" xml:space="preserve">
+    <value>Пароль:</value>
+  </data>
+  <data name="FtpAnonymous" xml:space="preserve">
+    <value>Анонимный вход</value>
+  </data>
+  <data name="FtpConnectButton" xml:space="preserve">
+    <value>Подключиться</value>
+  </data>
+  <data name="FtpConnectionFailed" xml:space="preserve">
+    <value>Не удалось подключиться к FTP-серверу: {0}</value>
+  </data>
 </root>

--- a/src/SmartCommander/Assets/Resources.ru-RU.resx
+++ b/src/SmartCommander/Assets/Resources.ru-RU.resx
@@ -127,13 +127,13 @@
     <value>Отмена</value>
   </data>
   <data name="CantCopyFileHere" xml:space="preserve">
-    <value>Невозможно скопировать файл сюда</value>
+    <value>Невозможно скопировать файл сюда: {0}</value>
   </data>
   <data name="CantCopyFileToItself" xml:space="preserve">
     <value>Невозможно скопировать файлы в ту же директорию</value>
   </data>
   <data name="CantCopyFolderHere" xml:space="preserve">
-    <value>Невозможно скопировать папку сюда</value>
+    <value>Невозможно скопировать папку сюда: {0}</value>
   </data>
   <data name="CantCopyFolderToItself" xml:space="preserve">
     <value>Невозможно скопировать папку в саму себя</value>
@@ -144,20 +144,29 @@
   <data name="CantCreateFolder" xml:space="preserve">
     <value>Невозможно создать папку</value>
   </data>
+  <data name="CantDeleteFileHere" xml:space="preserve">
+    <value>Невозможно удалить файл: {0}</value>
+  </data>
+  <data name="CantDeleteFolderHere" xml:space="preserve">
+    <value>Невозможно удалить папку: {0}</value>
+  </data>
   <data name="CantEditFolder" xml:space="preserve">
     <value>Невозможно редактировать папку</value>
   </data>
   <data name="CantExtractArchive" xml:space="preserve">
     <value>Невозможно распаковать архив {0}</value>
   </data>
+  <data name="CantLoadDirectory" xml:space="preserve">
+    <value>Невозможно загрузить папку: {0}</value>
+  </data>
   <data name="CantMoveFileHere" xml:space="preserve">
-    <value>Невозможно переместить файл сюда</value>
+    <value>Невозможно переместить файл сюда: {0}</value>
   </data>
   <data name="CantMoveFileToItself" xml:space="preserve">
     <value>Невозможно переместить файлы в ту же директорию</value>
   </data>
   <data name="CantMoveFolderHere" xml:space="preserve">
-    <value>Невозможно переместить папку сюда</value>
+    <value>Невозможно переместить папку сюда: {0}</value>
   </data>
   <data name="CantMoveFolderToItself" xml:space="preserve">
     <value>Невозможно переместить папку в саму себя</value>
@@ -443,5 +452,20 @@
   </data>
   <data name="FtpConnectionFailed" xml:space="preserve">
     <value>Не удалось подключиться к FTP-серверу: {0}</value>
+  </data>
+  <data name="Download" xml:space="preserve">
+    <value>Скачать</value>
+  </data>
+  <data name="Upload" xml:space="preserve">
+    <value>Загрузить</value>
+  </data>
+  <data name="Move" xml:space="preserve">
+    <value>Переместить</value>
+  </data>
+  <data name="CantViewFtpFile" xml:space="preserve">
+    <value>Просмотр файлов по FTP пока не поддерживается</value>
+  </data>
+  <data name="CantEditFtpFile" xml:space="preserve">
+    <value>Редактирование файлов по FTP пока не поддерживается</value>
   </data>
 </root>

--- a/src/SmartCommander/Assets/Resources.ru-RU.resx
+++ b/src/SmartCommander/Assets/Resources.ru-RU.resx
@@ -468,4 +468,7 @@
   <data name="CantEditFtpFile" xml:space="preserve">
     <value>Редактирование файлов по FTP пока не поддерживается</value>
   </data>
+  <data name="CantOpenFtpFile" xml:space="preserve">
+    <value>Открытие файлов по FTP пока не поддерживается</value>
+  </data>
 </root>

--- a/src/SmartCommander/Assets/Resources.sr-Cyrl-RS.resx
+++ b/src/SmartCommander/Assets/Resources.sr-Cyrl-RS.resx
@@ -468,4 +468,7 @@
   <data name="CantEditFtpFile" xml:space="preserve">
     <value>Уређивање FTP фајлова још није подржано</value>
   </data>
+  <data name="CantOpenFtpFile" xml:space="preserve">
+    <value>Отварање FTP фајлова још није подржано</value>
+  </data>
 </root>

--- a/src/SmartCommander/Assets/Resources.sr-Cyrl-RS.resx
+++ b/src/SmartCommander/Assets/Resources.sr-Cyrl-RS.resx
@@ -127,13 +127,13 @@
     <value>Откажи</value>
   </data>
   <data name="CantCopyFileHere" xml:space="preserve">
-    <value>Овде не можете да копирате датотеку</value>
+    <value>Овде не можете да копирате датотеку: {0}</value>
   </data>
   <data name="CantCopyFileToItself" xml:space="preserve">
     <value>Не можете да копираjте датотеке у исту фасциклу</value>
   </data>
   <data name="CantCopyFolderHere" xml:space="preserve">
-    <value>Овде не можете да копирате фасциклу</value>
+    <value>Овде не можете да копирате фасциклу: {0}</value>
   </data>
   <data name="CantCopyFolderToItself" xml:space="preserve">
     <value>Не можете да копирате фасциклу у саму себе</value>
@@ -144,20 +144,29 @@
   <data name="CantCreateFolder" xml:space="preserve">
     <value>Не можете да направите фасциклу</value>
   </data>
+  <data name="CantDeleteFileHere" xml:space="preserve">
+    <value>Овде не можете да обришете датотеку: {0}</value>
+  </data>
+  <data name="CantDeleteFolderHere" xml:space="preserve">
+    <value>Овде не можете да обришете фасциклу: {0}</value>
+  </data>
   <data name="CantEditFolder" xml:space="preserve">
     <value>Не можете да уређиваjте фасциклу</value>
   </data>
   <data name="CantExtractArchive" xml:space="preserve">
     <value>Не можете да распакујете архиву {0}</value>
   </data>
+  <data name="CantLoadDirectory" xml:space="preserve">
+    <value>Не можете да учитате директоријум: {0}</value>
+  </data>
   <data name="CantMoveFileHere" xml:space="preserve">
-    <value>Овде не можете да преместите датотеку</value>
+    <value>Овде не можете да преместите датотеку: {0}</value>
   </data>
   <data name="CantMoveFileToItself" xml:space="preserve">
     <value>Не можете да преместите датотеке у исту фасциклу</value>
   </data>
   <data name="CantMoveFolderHere" xml:space="preserve">
-    <value>Овде не можете да преместите фасциклу</value>
+    <value>Овде не можете да преместите фасциклу: {0}</value>
   </data>
   <data name="CantMoveFolderToItself" xml:space="preserve">
     <value>Не можете да премјестите фасциклу у саму себе</value>
@@ -443,5 +452,20 @@
   </data>
   <data name="FtpConnectionFailed" xml:space="preserve">
     <value>Повезивање на FTP сервер није успело: {0}</value>
+  </data>
+  <data name="Download" xml:space="preserve">
+    <value>Преузми</value>
+  </data>
+  <data name="Upload" xml:space="preserve">
+    <value>Отпреми</value>
+  </data>
+  <data name="Move" xml:space="preserve">
+    <value>Премјести</value>
+  </data>
+  <data name="CantViewFtpFile" xml:space="preserve">
+    <value>Преглед FTP фајлова још није подржан</value>
+  </data>
+  <data name="CantEditFtpFile" xml:space="preserve">
+    <value>Уређивање FTP фајлова још није подржано</value>
   </data>
 </root>

--- a/src/SmartCommander/Assets/Resources.sr-Cyrl-RS.resx
+++ b/src/SmartCommander/Assets/Resources.sr-Cyrl-RS.resx
@@ -408,4 +408,40 @@
   <data name="License" xml:space="preserve">
     <value>Лиценца: GNU General Public License v3.0</value>
   </data>
+  <data name="MenuFtp" xml:space="preserve">
+    <value>_FTP</value>
+  </data>
+  <data name="MenuFtpConnect" xml:space="preserve">
+    <value>_Повежи се...</value>
+  </data>
+  <data name="MenuFtpDisconnect" xml:space="preserve">
+    <value>_Прекини везу</value>
+  </data>
+  <data name="FtpConnectTitle" xml:space="preserve">
+    <value>Повезивање на FTP сервер</value>
+  </data>
+  <data name="FtpSavedConnections" xml:space="preserve">
+    <value>Сачуване везе:</value>
+  </data>
+  <data name="FtpHost" xml:space="preserve">
+    <value>Хост:</value>
+  </data>
+  <data name="FtpPort" xml:space="preserve">
+    <value>Порт:</value>
+  </data>
+  <data name="FtpUsername" xml:space="preserve">
+    <value>Корисничко име:</value>
+  </data>
+  <data name="FtpPassword" xml:space="preserve">
+    <value>Лозинка:</value>
+  </data>
+  <data name="FtpAnonymous" xml:space="preserve">
+    <value>Анонимна пријава</value>
+  </data>
+  <data name="FtpConnectButton" xml:space="preserve">
+    <value>Повежи се</value>
+  </data>
+  <data name="FtpConnectionFailed" xml:space="preserve">
+    <value>Повезивање на FTP сервер није успело: {0}</value>
+  </data>
 </root>

--- a/src/SmartCommander/Assets/Resources.sr-Latn-ME.resx
+++ b/src/SmartCommander/Assets/Resources.sr-Latn-ME.resx
@@ -127,13 +127,13 @@
     <value>Otkaži</value>
   </data>
   <data name="CantCopyFileHere" xml:space="preserve">
-    <value>Ne možete da kopirate datoteku ovdje</value>
+    <value>Ne možete da kopirate datoteku ovdje: {0}</value>
   </data>
   <data name="CantCopyFileToItself" xml:space="preserve">
     <value>Ne možete da kopirajte datoteke u istu fasciklu</value>
   </data>
   <data name="CantCopyFolderHere" xml:space="preserve">
-    <value>Ne možete da kopirate fasciklu ovdje</value>
+    <value>Ne možete da kopirate fasciklu ovdje: {0}</value>
   </data>
   <data name="CantCopyFolderToItself" xml:space="preserve">
     <value>Ne možete da kopirate fasciklu u samu sebe</value>
@@ -144,20 +144,29 @@
   <data name="CantCreateFolder" xml:space="preserve">
     <value>Ne možete da napravite fasciklu</value>
   </data>
+  <data name="CantDeleteFileHere" xml:space="preserve">
+    <value>Ne možete da obrišete datoteku ovdje: {0}</value>
+  </data>
+  <data name="CantDeleteFolderHere" xml:space="preserve">
+    <value>Ne možete da obrišete fasciklu ovdje: {0}</value>
+  </data>
   <data name="CantEditFolder" xml:space="preserve">
     <value>Ne možete da uređivajte fasciklu</value>
   </data>
   <data name="CantExtractArchive" xml:space="preserve">
     <value>Ne možete da raspakujete arhivu {0}</value>
   </data>
+  <data name="CantLoadDirectory" xml:space="preserve">
+    <value>Ne možete da učitate direktorijum: {0}</value>
+  </data>
   <data name="CantMoveFileHere" xml:space="preserve">
-    <value>Ne možete da premjestite datoteku ovdje</value>
+    <value>Ne možete da premjestite datoteku ovdje: {0}</value>
   </data>
   <data name="CantMoveFileToItself" xml:space="preserve">
     <value>Ne možete da premjestite datoteke u istu fasciklu</value>
   </data>
   <data name="CantMoveFolderHere" xml:space="preserve">
-    <value>Ne možete da premjestite fasciklu ovdje</value>
+    <value>Ne možete da premjestite fasciklu ovdje: {0}</value>
   </data>
   <data name="CantMoveFolderToItself" xml:space="preserve">
     <value>Ne možete da premjestite fasciklu u samu sebe</value>
@@ -443,5 +452,20 @@
   </data>
   <data name="FtpConnectionFailed" xml:space="preserve">
     <value>Povezivanje na FTP server nije uspelo: {0}</value>
+  </data>
+  <data name="Download" xml:space="preserve">
+    <value>Preuzmi</value>
+  </data>
+  <data name="Upload" xml:space="preserve">
+    <value>Otpremi</value>
+  </data>
+  <data name="Move" xml:space="preserve">
+    <value>Premjesti</value>
+  </data>
+  <data name="CantViewFtpFile" xml:space="preserve">
+    <value>Pregled FTP fajlova još nije podržan</value>
+  </data>
+  <data name="CantEditFtpFile" xml:space="preserve">
+    <value>Uređivanje FTP fajlova još nije podržano</value>
   </data>
 </root>

--- a/src/SmartCommander/Assets/Resources.sr-Latn-ME.resx
+++ b/src/SmartCommander/Assets/Resources.sr-Latn-ME.resx
@@ -468,4 +468,7 @@
   <data name="CantEditFtpFile" xml:space="preserve">
     <value>Uređivanje FTP fajlova još nije podržano</value>
   </data>
+  <data name="CantOpenFtpFile" xml:space="preserve">
+    <value>Otvaranje FTP fajlova još nije podržano</value>
+  </data>
 </root>

--- a/src/SmartCommander/Assets/Resources.sr-Latn-ME.resx
+++ b/src/SmartCommander/Assets/Resources.sr-Latn-ME.resx
@@ -408,4 +408,40 @@
   <data name="License" xml:space="preserve">
     <value>Licenca: GNU General Public License v3.0</value>
   </data>
+  <data name="MenuFtp" xml:space="preserve">
+    <value>_FTP</value>
+  </data>
+  <data name="MenuFtpConnect" xml:space="preserve">
+    <value>_Poveži se...</value>
+  </data>
+  <data name="MenuFtpDisconnect" xml:space="preserve">
+    <value>_Prekini vezu</value>
+  </data>
+  <data name="FtpConnectTitle" xml:space="preserve">
+    <value>Povezivanje na FTP server</value>
+  </data>
+  <data name="FtpSavedConnections" xml:space="preserve">
+    <value>Sačuvane veze:</value>
+  </data>
+  <data name="FtpHost" xml:space="preserve">
+    <value>Host:</value>
+  </data>
+  <data name="FtpPort" xml:space="preserve">
+    <value>Port:</value>
+  </data>
+  <data name="FtpUsername" xml:space="preserve">
+    <value>Korisničko ime:</value>
+  </data>
+  <data name="FtpPassword" xml:space="preserve">
+    <value>Lozinka:</value>
+  </data>
+  <data name="FtpAnonymous" xml:space="preserve">
+    <value>Anonimna prijava</value>
+  </data>
+  <data name="FtpConnectButton" xml:space="preserve">
+    <value>Poveži se</value>
+  </data>
+  <data name="FtpConnectionFailed" xml:space="preserve">
+    <value>Povezivanje na FTP server nije uspelo: {0}</value>
+  </data>
 </root>

--- a/src/SmartCommander/Models/FtpConnectionsModel.cs
+++ b/src/SmartCommander/Models/FtpConnectionsModel.cs
@@ -1,0 +1,64 @@
+using Newtonsoft.Json;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using static System.Environment;
+
+namespace SmartCommander.Models
+{
+    // A saved connection profile. Password is deliberately not a member here - it's never
+    // persisted, the connect dialog always prompts for it.
+    public class FtpConnectionProfile
+    {
+        public string Name { get; set; } = "";
+        public string Host { get; set; } = "";
+        public int Port { get; set; } = 21;
+        public string Username { get; set; } = "";
+        public bool Anonymous { get; set; }
+    }
+
+    public class FtpConnectionsModel
+    {
+        public static FtpConnectionsModel Instance { get; private set; } = new FtpConnectionsModel();
+        private static readonly string _settingsDir = Path.Combine(GetFolderPath(SpecialFolder.ApplicationData), "SmartCommander");
+        private static readonly string _settingsPath = Path.Combine(_settingsDir, "ftpconnections.json");
+
+        static FtpConnectionsModel()
+        {
+            Directory.CreateDirectory(_settingsDir);
+            if (File.Exists(_settingsPath))
+            {
+                try
+                {
+                    var model = JsonConvert.DeserializeObject<FtpConnectionsModel>(File.ReadAllText(_settingsPath));
+                    if (model != null)
+                    {
+                        Instance = model;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, "Failed to load {SettingsPath}; falling back to no saved connections", _settingsPath);
+                    try
+                    {
+                        File.Move(_settingsPath, _settingsPath + ".corrupt", overwrite: true);
+                    }
+                    catch (Exception moveEx)
+                    {
+                        Log.Error(moveEx, "Failed to move corrupt FTP connections file {SettingsPath} aside", _settingsPath);
+                    }
+                }
+            }
+        }
+
+        public void Save()
+        {
+            string tempPath = _settingsPath + ".tmp";
+            File.WriteAllText(tempPath, JsonConvert.SerializeObject(this, Formatting.Indented));
+            File.Move(tempPath, _settingsPath, overwrite: true);
+        }
+
+        public List<FtpConnectionProfile> Connections { get; set; } = [];
+    }
+}

--- a/src/SmartCommander/Models/FtpConnectionsModel.cs
+++ b/src/SmartCommander/Models/FtpConnectionsModel.cs
@@ -16,6 +16,7 @@ namespace SmartCommander.Models
         public int Port { get; set; } = 21;
         public string Username { get; set; } = "";
         public bool Anonymous { get; set; }
+        public DateTime LastUsed { get; set; }
     }
 
     public class FtpConnectionsModel

--- a/src/SmartCommander/Services/FileSystemService.cs
+++ b/src/SmartCommander/Services/FileSystemService.cs
@@ -1,82 +1,226 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace SmartCommander.Services
 {
     // Composite the ViewModels talk to: dispatches each call to the provider that
-    // owns the path. Only the local provider exists so far.
+    // owns the path (scheme-based, see RemotePath). At most one FTP connection is
+    // ever active app-wide, so _ftpProvider is a single nullable field rather than
+    // a keyed collection.
     public class FileSystemService : IFileSystemService
     {
         private readonly IFileSystemProvider _local;
+        private FtpFileSystemProvider? _ftpProvider;
 
         public FileSystemService(IFileSystemProvider local)
         {
             _local = local;
         }
 
+        public bool IsFtpConnected => _ftpProvider?.IsConnected == true;
+        public string? FtpHost => _ftpProvider?.Host;
+
+        public async Task ConnectFtpAsync(string host, int port, string username, string password, bool anonymous, CancellationToken ct)
+        {
+            if (_ftpProvider != null)
+            {
+                await DisconnectFtpAsync();
+            }
+            var provider = new FtpFileSystemProvider();
+            await provider.ConnectAsync(host, port, username, password, anonymous, ct);
+            _ftpProvider = provider;
+        }
+
+        public async Task DisconnectFtpAsync()
+        {
+            if (_ftpProvider == null)
+            {
+                return;
+            }
+            await _ftpProvider.DisposeAsync();
+            _ftpProvider = null;
+        }
+
+        private IFileSystemProvider ProviderFor(string path) =>
+            RemotePath.IsFtp(path)
+                ? (_ftpProvider ?? throw new InvalidOperationException("No FTP connection active."))
+                : _local;
+
+        private FtpFileSystemProvider Ftp =>
+            _ftpProvider ?? throw new InvalidOperationException("No FTP connection active.");
+
         public Task<IReadOnlyList<string>> GetDirectoriesAsync(string path, DirectoryListingFilter filter, CancellationToken ct) =>
-            _local.GetDirectoriesAsync(path, filter, ct);
+            ProviderFor(path).GetDirectoriesAsync(path, filter, ct);
 
         public Task<IReadOnlyList<string>> GetFilesAsync(string path, DirectoryListingFilter filter, CancellationToken ct) =>
-            _local.GetFilesAsync(path, filter, ct);
+            ProviderFor(path).GetFilesAsync(path, filter, ct);
 
         public Task<bool> DirectoryExistsAsync(string path, CancellationToken ct = default) =>
-            _local.DirectoryExistsAsync(path, ct);
+            ProviderFor(path).DirectoryExistsAsync(path, ct);
+
+        public Task<bool> FileExistsAsync(string path, CancellationToken ct = default) =>
+            ProviderFor(path).FileExistsAsync(path, ct);
 
         public Task<string?> GetDirectoryParentAsync(string path, CancellationToken ct = default) =>
-            _local.GetDirectoryParentAsync(path, ct);
+            ProviderFor(path).GetDirectoryParentAsync(path, ct);
 
         public Task<string?> GetPathRootAsync(string path, CancellationToken ct = default) =>
-            _local.GetPathRootAsync(path, ct);
+            ProviderFor(path).GetPathRootAsync(path, ct);
 
         public Task<long> GetFileSizeAsync(string path) =>
-            _local.GetFileSizeAsync(path);
+            ProviderFor(path).GetFileSizeAsync(path);
 
         public Task<DateTime> GetCreationTimeAsync(string path) =>
-            _local.GetCreationTimeAsync(path);
+            ProviderFor(path).GetCreationTimeAsync(path);
 
-        public Task<long> GetTotalSizeAsync(IReadOnlyList<(string FullName, bool IsFolder)> items) =>
-            _local.GetTotalSizeAsync(items);
+        public Task<long> GetTotalSizeAsync(IReadOnlyList<(string FullName, bool IsFolder)> items)
+        {
+            if (items.Count == 0)
+            {
+                return Task.FromResult(0L);
+            }
+            // Items always come from a single pane's selection, so they share one provider.
+            return ProviderFor(items[0].FullName).GetTotalSizeAsync(items);
+        }
 
         public Task MoveFileAsync(string source, string dest) =>
-            _local.MoveFileAsync(source, dest);
+            ProviderFor(source).MoveFileAsync(source, dest);
 
         public Task MoveDirectoryAsync(string source, string dest) =>
-            _local.MoveDirectoryAsync(source, dest);
+            ProviderFor(source).MoveDirectoryAsync(source, dest);
 
         public Task RenameAsync(string oldPath, string newPath, bool isFolder) =>
-            _local.RenameAsync(oldPath, newPath, isFolder);
+            ProviderFor(oldPath).RenameAsync(oldPath, newPath, isFolder);
 
         public Task CreateDirectoryAsync(string path) =>
-            _local.CreateDirectoryAsync(path);
+            ProviderFor(path).CreateDirectoryAsync(path);
 
         public Task DeleteFileAsync(string path) =>
-            _local.DeleteFileAsync(path);
+            ProviderFor(path).DeleteFileAsync(path);
 
         public Task DeleteDirectoryAsync(string path, CancellationToken ct = default) =>
-            _local.DeleteDirectoryAsync(path, ct);
+            ProviderFor(path).DeleteDirectoryAsync(path, ct);
 
+        // Local<->FTP transfers are the only cross-provider case (FTP<->FTP can't occur — at
+        // most one pane is ever FTP). Same-provider transfers fall through to that provider's
+        // own implementation unchanged.
         public Task<long> CopyFileAsync(string source, string dest, bool delete, bool overwrite,
                                         IProgress<int>? progress, long processedSize, long totalSize,
-                                        CancellationToken ct) =>
-            _local.CopyFileAsync(source, dest, delete, overwrite, progress, processedSize, totalSize, ct);
+                                        CancellationToken ct)
+        {
+            bool sourceFtp = RemotePath.IsFtp(source);
+            bool destFtp = RemotePath.IsFtp(dest);
+            if (!sourceFtp && !destFtp)
+            {
+                return _local.CopyFileAsync(source, dest, delete, overwrite, progress, processedSize, totalSize, ct);
+            }
+            if (!sourceFtp)
+            {
+                return Ftp.UploadFileAsync(source, dest, delete, overwrite, progress, processedSize, totalSize, ct);
+            }
+            if (!destFtp)
+            {
+                return Ftp.DownloadFileAsync(source, dest, delete, overwrite, progress, processedSize, totalSize, ct);
+            }
+            throw new NotSupportedException("FTP-to-FTP transfers are not supported.");
+        }
 
         public Task<long> CopyDirectoryAsync(string source, string dest, bool recursive, bool delete, bool overwrite,
                                              IProgress<int>? progress, long processedSize, long totalSize,
-                                             CancellationToken ct) =>
-            _local.CopyDirectoryAsync(source, dest, recursive, delete, overwrite, progress, processedSize, totalSize, ct);
+                                             CancellationToken ct)
+        {
+            bool sourceFtp = RemotePath.IsFtp(source);
+            bool destFtp = RemotePath.IsFtp(dest);
+            if (!sourceFtp && !destFtp)
+            {
+                return _local.CopyDirectoryAsync(source, dest, recursive, delete, overwrite, progress, processedSize, totalSize, ct);
+            }
+            if (!sourceFtp)
+            {
+                return Ftp.UploadDirectoryAsync(source, dest, delete, overwrite, progress, processedSize, totalSize, ct);
+            }
+            if (!destFtp)
+            {
+                return Ftp.DownloadDirectoryAsync(source, dest, delete, overwrite, progress, processedSize, totalSize, ct);
+            }
+            throw new NotSupportedException("FTP-to-FTP transfers are not supported.");
+        }
 
         public Task SearchAsync(string folder, string pattern, bool topOnly, bool searchContent,
                                 string contentText, IProgress<string> results,
                                 IProgress<string>? statusProgress, CancellationToken ct) =>
-            _local.SearchAsync(folder, pattern, topOnly, searchContent, contentText, results, statusProgress, ct);
+            ProviderFor(folder).SearchAsync(folder, pattern, topOnly, searchContent, contentText, results, statusProgress, ct);
 
-        public Task<List<string>> GetDuplicatesAsync(IReadOnlyList<(string FullName, bool IsFolder)> items, string destPath) =>
-            _local.GetDuplicatesAsync(items, destPath);
+        // items (the drag/paste source) and destPath (the other pane) can belong to different
+        // providers — e.g. selecting local files and pasting into an FTP-browsed pane. When they
+        // match, delegate straight to that provider (existing behavior); when they don't, walk
+        // the source tree via the source provider and check existence via the destination
+        // provider, matching each provider's own recursive-duplicate logic one level up.
+        public async Task<List<string>> GetDuplicatesAsync(IReadOnlyList<(string FullName, bool IsFolder)> items, string destPath)
+        {
+            if (items.Count == 0)
+            {
+                return new List<string>();
+            }
+            bool sourceFtp = RemotePath.IsFtp(items[0].FullName);
+            bool destFtp = RemotePath.IsFtp(destPath);
+            if (sourceFtp == destFtp)
+            {
+                return await (sourceFtp ? Ftp : _local).GetDuplicatesAsync(items, destPath);
+            }
 
-        public Task<List<string>> GetNonEmptyFoldersAsync(IReadOnlyList<(string FullName, bool IsFolder)> items) =>
-            _local.GetNonEmptyFoldersAsync(items);
+            var srcProvider = sourceFtp ? Ftp : (IFileSystemProvider)_local;
+            var destProvider = destFtp ? Ftp : (IFileSystemProvider)_local;
+            var duplicates = new List<string>();
+            foreach (var (fullName, isFolder) in items)
+            {
+                var targetPath = RemotePath.CombineChild(destPath, Path.GetFileName(fullName));
+                if (isFolder)
+                {
+                    await CollectCrossDuplicatesAsync(srcProvider, destProvider, fullName, targetPath, duplicates);
+                }
+                else if (await destProvider.FileExistsAsync(targetPath))
+                {
+                    duplicates.Add(fullName);
+                }
+            }
+            return duplicates;
+        }
+
+        private static async Task CollectCrossDuplicatesAsync(IFileSystemProvider srcProvider, IFileSystemProvider destProvider,
+            string sourceDir, string destDir, List<string> duplicates)
+        {
+            if (!await srcProvider.DirectoryExistsAsync(sourceDir))
+            {
+                return;
+            }
+            var filter = new DirectoryListingFilter();
+            foreach (var file in await srcProvider.GetFilesAsync(sourceDir, filter, CancellationToken.None))
+            {
+                var targetPath = RemotePath.CombineChild(destDir, Path.GetFileName(file));
+                if (await destProvider.FileExistsAsync(targetPath))
+                {
+                    duplicates.Add(file);
+                }
+            }
+            foreach (var dir in await srcProvider.GetDirectoriesAsync(sourceDir, filter, CancellationToken.None))
+            {
+                var targetSubDir = RemotePath.CombineChild(destDir, Path.GetFileName(dir));
+                await CollectCrossDuplicatesAsync(srcProvider, destProvider, dir, targetSubDir, duplicates);
+            }
+        }
+
+        public Task<List<string>> GetNonEmptyFoldersAsync(IReadOnlyList<(string FullName, bool IsFolder)> items)
+        {
+            if (items.Count == 0)
+            {
+                return Task.FromResult(new List<string>());
+            }
+            // Items always come from a single pane's selection, so they share one provider.
+            return ProviderFor(items[0].FullName).GetNonEmptyFoldersAsync(items);
+        }
     }
 }

--- a/src/SmartCommander/Services/FtpFileSystemProvider.cs
+++ b/src/SmartCommander/Services/FtpFileSystemProvider.cs
@@ -12,17 +12,13 @@ using System.Threading.Tasks;
 
 namespace SmartCommander.Services
 {
-    // Backed by FluentFTP's AsyncFtpClient. Exactly one instance exists at a time (owned by
-    // the composite FileSystemService, created on connect, disposed on disconnect) since only
-    // one FTP connection is ever active app-wide. All paths passed into this provider are full
-    // "ftp://" strings (see RemotePath); FluentFTP only ever sees the remote part.
+    // Backed by FluentFTP's AsyncFtpClient. Exactly one instance exists at a time (owned by the
+    // composite FileSystemService), since only one FTP connection is ever active app-wide. Paths
+    // passed in are full "ftp://" strings (see RemotePath); FluentFTP only sees the remote part.
     //
-    // A single FTP control connection can only run one command at a time - unlike local disk
-    // access, two commands issued concurrently on the same AsyncFtpClient corrupt the connection
-    // (garbled command/response state, spurious timeouts). Every method that touches the client
-    // acquires _lock first, so calls queue instead of interleaving; callers that used to run two
-    // requests in parallel against the local provider (e.g. listing files and folders together)
-    // now run them one after another here.
+    // A control connection can only run one command at a time - concurrent commands on the same
+    // AsyncFtpClient corrupt it (garbled responses, spurious timeouts). Every method acquires
+    // _lock first, so calls queue instead of interleaving.
     public class FtpFileSystemProvider : IFileSystemProvider, IAsyncDisposable
     {
         private readonly SemaphoreSlim _lock = new(1, 1);
@@ -227,6 +223,14 @@ namespace SmartCommander.Services
                 var status = await Client.UploadFile(localSource, RemotePath.GetRemotePart(ftpDest), existsMode,
                     false, FtpVerify.None, adapter, ct);
 
+                // UploadFile reports a server-side rejection (e.g. read-only account, quota,
+                // permission error) via FtpStatus.Failed rather than an exception, and gives no
+                // exception/result object to inspect - use the server's own reply text instead.
+                if (status == FtpStatus.Failed)
+                {
+                    throw new IOException($"Server rejected the upload of {Path.GetFileName(localSource)}. {Client.LastReply.ErrorMessage}".TrimEnd());
+                }
+
                 long processed = processedSize + (status == FtpStatus.Skipped ? 0 : fileSize);
                 ReportProgress(progress, processed, totalSize);
 
@@ -257,6 +261,14 @@ namespace SmartCommander.Services
                 var status = await Client.DownloadFile(localDest, remoteSource, FtpLocalExists.Overwrite,
                     FtpVerify.None, adapter, ct);
 
+                // Same silent-failure shape as UploadFileAsync above: DownloadFile reports a
+                // server-side failure via FtpStatus.Failed rather than an exception, and the
+                // single-file overload gives no exception object - use LastReply instead.
+                if (status == FtpStatus.Failed)
+                {
+                    throw new IOException($"Failed to download {Path.GetFileName(remoteSource)}. {Client.LastReply.ErrorMessage}".TrimEnd());
+                }
+
                 long processed = processedSize + fileSize;
                 ReportProgress(progress, processed, totalSize);
 
@@ -275,8 +287,19 @@ namespace SmartCommander.Services
             {
                 var dirSize = GetLocalDirectorySize(localSource);
                 var adapter = new FtpProgressAdapter(progress, processedSize, totalSize, dirSize);
-                await Client.UploadDirectory(localSource, RemotePath.GetRemotePart(ftpDest), FtpFolderSyncMode.Update,
+                var results = await Client.UploadDirectory(localSource, RemotePath.GetRemotePart(ftpDest), FtpFolderSyncMode.Update,
                     overwrite ? FtpRemoteExists.Overwrite : FtpRemoteExists.Skip, FtpVerify.None, null, adapter, ct);
+
+                // UploadDirectory catches every per-file exception into its FtpResult list
+                // instead of throwing - without this check a rejected folder upload (e.g. a
+                // read-only account) would silently no-op instead of surfacing an error. List
+                // every failed file, not just the first, so the user knows the true scope.
+                var failed = results.Where(r => r.IsFailed).ToList();
+                if (failed.Count > 0)
+                {
+                    throw new IOException($"Server rejected the upload of: {string.Join(", ", failed.Select(f => f.Name))}.",
+                        failed[0].Exception);
+                }
 
                 long processed = processedSize + dirSize;
                 ReportProgress(progress, processed, totalSize);
@@ -297,8 +320,18 @@ namespace SmartCommander.Services
                 var remoteSource = RemotePath.GetRemotePart(ftpSource);
                 var dirSize = await GetDirectorySizeAsync(ftpSource);
                 var adapter = new FtpProgressAdapter(progress, processedSize, totalSize, dirSize);
-                await Client.DownloadDirectory(localDest, remoteSource, FtpFolderSyncMode.Update,
+                var results = await Client.DownloadDirectory(localDest, remoteSource, FtpFolderSyncMode.Update,
                     overwrite ? FtpLocalExists.Overwrite : FtpLocalExists.Skip, FtpVerify.None, null, adapter, ct);
+
+                // Same silent-failure shape as UploadDirectoryAsync above: per-file exceptions
+                // land in the FtpResult list instead of throwing. List every failed file, not
+                // just the first, so the user knows the true scope.
+                var failed = results.Where(r => r.IsFailed).ToList();
+                if (failed.Count > 0)
+                {
+                    throw new IOException($"Failed to download: {string.Join(", ", failed.Select(f => f.Name))}.",
+                        failed[0].Exception);
+                }
 
                 long processed = processedSize + dirSize;
                 ReportProgress(progress, processed, totalSize);
@@ -492,12 +525,10 @@ namespace SmartCommander.Services
             progress.Report(totalSize == 0 ? 0 : Convert.ToInt32(processedSize * 100 / totalSize));
         }
 
-        // Adapts FluentFTP's per-item IProgress<FtpProgress> to the cumulative-across-the-whole-
-        // operation IProgress<int> (0-100) that FileOperationViewModel expects, matching
-        // LocalFileSystemProvider's processedSize/totalSize accumulation contract. Prefers
-        // FtpProgress.TransferredBytes (cumulative bytes for this transfer); falls back to
-        // Progress% scaled against a known item size (used for directory transfers, where
-        // TransferredBytes semantics are less reliable across multiple files).
+        // Adapts FluentFTP's per-item IProgress<FtpProgress> to the cumulative 0-100 IProgress<int>
+        // that FileOperationViewModel expects. Prefers TransferredBytes (cumulative for this
+        // transfer); falls back to Progress% scaled against a known item size, since
+        // TransferredBytes is less reliable across multiple files in a directory transfer.
         private sealed class FtpProgressAdapter : IProgress<FtpProgress>
         {
             private readonly IProgress<int>? _progress;

--- a/src/SmartCommander/Services/FtpFileSystemProvider.cs
+++ b/src/SmartCommander/Services/FtpFileSystemProvider.cs
@@ -1,0 +1,497 @@
+using FluentFTP;
+using Serilog;
+using SmartCommander.Models;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SmartCommander.Services
+{
+    // Backed by FluentFTP's AsyncFtpClient. Exactly one instance exists at a time (owned by
+    // the composite FileSystemService, created on connect, disposed on disconnect) since only
+    // one FTP connection is ever active app-wide. All paths passed into this provider are full
+    // "ftp://" strings (see RemotePath); FluentFTP only ever sees the remote part.
+    public class FtpFileSystemProvider : IFileSystemProvider, IAsyncDisposable
+    {
+        private AsyncFtpClient? _client;
+
+        public string? Host { get; private set; }
+        public bool IsConnected => _client is { IsConnected: true };
+
+        public async Task ConnectAsync(string host, int port, string username, string password, bool anonymous, CancellationToken ct)
+        {
+            var client = new AsyncFtpClient(host, anonymous ? "anonymous" : username, anonymous ? "" : password, port);
+            try
+            {
+                await client.AutoConnect(ct);
+            }
+            catch
+            {
+                client.Dispose();
+                throw;
+            }
+            _client = client;
+            Host = host;
+        }
+
+        public async Task DisconnectAsync()
+        {
+            if (_client == null)
+            {
+                return;
+            }
+            await _client.Disconnect();
+            _client.Dispose();
+            _client = null;
+            Host = null;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            var task = DisconnectAsync();
+            return new ValueTask(task);
+        }
+
+        private AsyncFtpClient Client =>
+            _client ?? throw new InvalidOperationException("Not connected to an FTP server.");
+
+        public async Task<IReadOnlyList<string>> GetDirectoriesAsync(string path, DirectoryListingFilter filter, CancellationToken ct)
+        {
+            var listing = await Client.GetListing(RemotePath.GetRemotePart(path), ToFtpListOption(filter), ct);
+            return listing
+                .Where(i => i.Type == FtpObjectType.Directory)
+                .Where(i => filter.IncludeHidden || !IsDotfile(i))
+                .Select(i => RemotePath.Combine(i.FullName))
+                .ToList();
+        }
+
+        public async Task<IReadOnlyList<string>> GetFilesAsync(string path, DirectoryListingFilter filter, CancellationToken ct)
+        {
+            var listing = await Client.GetListing(RemotePath.GetRemotePart(path), ToFtpListOption(filter), ct);
+            return listing
+                .Where(i => i.Type == FtpObjectType.File)
+                .Where(i => filter.IncludeHidden || !IsDotfile(i))
+                .Select(i => RemotePath.Combine(i.FullName))
+                .ToList();
+        }
+
+        // FTP has no Windows-style hidden attribute; mirror the Linux dotfile convention
+        // LocalFileSystemProvider already applies for IncludeHidden.
+        private static bool IsDotfile(FtpListItem item) => item.Name.StartsWith('.');
+
+        private static FtpListOption ToFtpListOption(DirectoryListingFilter filter)
+        {
+            var options = FtpListOption.Auto;
+            if (filter.IncludeHidden)
+            {
+                options |= FtpListOption.AllFiles;
+            }
+            if (filter.Recursive)
+            {
+                options |= FtpListOption.Recursive;
+            }
+            return options;
+        }
+
+        public Task<bool> DirectoryExistsAsync(string path, CancellationToken ct = default) =>
+            Client.DirectoryExists(RemotePath.GetRemotePart(path), ct);
+
+        public Task<bool> FileExistsAsync(string path, CancellationToken ct = default) =>
+            Client.FileExists(RemotePath.GetRemotePart(path), ct);
+
+        // Pure path math against the ftp:// scheme — no network call needed.
+        public Task<string?> GetDirectoryParentAsync(string path, CancellationToken ct = default)
+        {
+            var trimmed = RemotePath.GetRemotePart(path).TrimEnd('/');
+            if (trimmed.Length == 0)
+            {
+                return Task.FromResult<string?>(null);
+            }
+            var lastSlash = trimmed.LastIndexOf('/');
+            var parent = lastSlash <= 0 ? "/" : trimmed.Substring(0, lastSlash);
+            return Task.FromResult<string?>(RemotePath.Combine(parent));
+        }
+
+        // FTP has no drive concept; the root is always "/".
+        public Task<string?> GetPathRootAsync(string path, CancellationToken ct = default) =>
+            Task.FromResult<string?>(RemotePath.Combine("/"));
+
+        public Task<long> GetFileSizeAsync(string path) =>
+            Client.GetFileSize(RemotePath.GetRemotePart(path));
+
+        // FTP (via MDTM) only exposes a modified time, not a creation time; used as the
+        // closest available approximation for FileViewModel's metadata display.
+        public Task<DateTime> GetCreationTimeAsync(string path) =>
+            Client.GetModifiedTime(RemotePath.GetRemotePart(path));
+
+        public async Task<long> GetTotalSizeAsync(IReadOnlyList<(string FullName, bool IsFolder)> items)
+        {
+            long total = 0;
+            foreach (var (fullName, isFolder) in items)
+            {
+                total += isFolder
+                    ? await GetDirectorySizeAsync(fullName)
+                    : await Client.GetFileSize(RemotePath.GetRemotePart(fullName));
+            }
+            return total;
+        }
+
+        private async Task<long> GetDirectorySizeAsync(string path)
+        {
+            var listing = await Client.GetListing(RemotePath.GetRemotePart(path), FtpListOption.Recursive, CancellationToken.None);
+            return listing.Where(i => i.Type == FtpObjectType.File).Sum(i => i.Size);
+        }
+
+        public Task MoveFileAsync(string source, string dest) =>
+            Client.MoveFile(RemotePath.GetRemotePart(source), RemotePath.GetRemotePart(dest));
+
+        public Task MoveDirectoryAsync(string source, string dest) =>
+            Client.MoveDirectory(RemotePath.GetRemotePart(source), RemotePath.GetRemotePart(dest));
+
+        public Task RenameAsync(string oldPath, string newPath, bool isFolder) =>
+            Client.Rename(RemotePath.GetRemotePart(oldPath), RemotePath.GetRemotePart(newPath));
+
+        public Task CreateDirectoryAsync(string path) =>
+            Client.CreateDirectory(RemotePath.GetRemotePart(path));
+
+        public Task DeleteFileAsync(string path) =>
+            Client.DeleteFile(RemotePath.GetRemotePart(path));
+
+        public Task DeleteDirectoryAsync(string path, CancellationToken ct = default) =>
+            Client.DeleteDirectory(RemotePath.GetRemotePart(path), ct);
+
+        // Required by IFileSystemProvider, but unreachable via the composite's dispatch:
+        // FTP-to-FTP never occurs since at most one pane is ever FTP. Local<->FTP transfers
+        // go through UploadFileAsync/DownloadFileAsync below instead.
+        public Task<long> CopyFileAsync(string source, string dest, bool delete, bool overwrite,
+                                        IProgress<int>? progress, long processedSize, long totalSize,
+                                        CancellationToken ct) =>
+            throw new NotSupportedException("FTP-to-FTP transfers are not supported.");
+
+        public Task<long> CopyDirectoryAsync(string source, string dest, bool recursive, bool delete, bool overwrite,
+                                             IProgress<int>? progress, long processedSize, long totalSize,
+                                             CancellationToken ct) =>
+            throw new NotSupportedException("FTP-to-FTP transfers are not supported.");
+
+        // Called by the composite for a local -> FTP file transfer.
+        public async Task<long> UploadFileAsync(string localSource, string ftpDest, bool delete, bool overwrite,
+                                                 IProgress<int>? progress, long processedSize, long totalSize,
+                                                 CancellationToken ct)
+        {
+            var fileSize = new FileInfo(localSource).Length;
+            var existsMode = overwrite ? FtpRemoteExists.Overwrite : FtpRemoteExists.Skip;
+            var adapter = new FtpProgressAdapter(progress, processedSize, totalSize);
+            var status = await Client.UploadFile(localSource, RemotePath.GetRemotePart(ftpDest), existsMode,
+                false, FtpVerify.None, adapter, ct);
+
+            long processed = processedSize + (status == FtpStatus.Skipped ? 0 : fileSize);
+            ReportProgress(progress, processed, totalSize);
+
+            if (status != FtpStatus.Skipped && delete)
+            {
+                File.Delete(localSource);
+            }
+            return processed;
+        }
+
+        // Called by the composite for an FTP -> local file transfer.
+        public async Task<long> DownloadFileAsync(string ftpSource, string localDest, bool delete, bool overwrite,
+                                                   IProgress<int>? progress, long processedSize, long totalSize,
+                                                   CancellationToken ct)
+        {
+            var remoteSource = RemotePath.GetRemotePart(ftpSource);
+            var fileSize = Math.Max(0, await Client.GetFileSize(remoteSource, -1, ct));
+
+            if (!overwrite && File.Exists(localDest))
+            {
+                long skipped = processedSize + fileSize;
+                ReportProgress(progress, skipped, totalSize);
+                return skipped;
+            }
+
+            var adapter = new FtpProgressAdapter(progress, processedSize, totalSize);
+            var status = await Client.DownloadFile(localDest, remoteSource, FtpLocalExists.Overwrite,
+                FtpVerify.None, adapter, ct);
+
+            long processed = processedSize + fileSize;
+            ReportProgress(progress, processed, totalSize);
+
+            if (status == FtpStatus.Success && delete)
+            {
+                await Client.DeleteFile(remoteSource, ct);
+            }
+            return processed;
+        }
+
+        // Called by the composite for a local -> FTP directory transfer.
+        public async Task<long> UploadDirectoryAsync(string localSource, string ftpDest, bool delete, bool overwrite,
+                                                      IProgress<int>? progress, long processedSize, long totalSize,
+                                                      CancellationToken ct)
+        {
+            var dirSize = GetLocalDirectorySize(localSource);
+            var adapter = new FtpProgressAdapter(progress, processedSize, totalSize, dirSize);
+            await Client.UploadDirectory(localSource, RemotePath.GetRemotePart(ftpDest), FtpFolderSyncMode.Update,
+                overwrite ? FtpRemoteExists.Overwrite : FtpRemoteExists.Skip, FtpVerify.None, null, adapter, ct);
+
+            long processed = processedSize + dirSize;
+            ReportProgress(progress, processed, totalSize);
+
+            if (delete)
+            {
+                Directory.Delete(localSource, true);
+            }
+            return processed;
+        }
+
+        // Called by the composite for an FTP -> local directory transfer.
+        public async Task<long> DownloadDirectoryAsync(string ftpSource, string localDest, bool delete, bool overwrite,
+                                                        IProgress<int>? progress, long processedSize, long totalSize,
+                                                        CancellationToken ct)
+        {
+            var remoteSource = RemotePath.GetRemotePart(ftpSource);
+            var dirSize = await GetDirectorySizeAsync(ftpSource);
+            var adapter = new FtpProgressAdapter(progress, processedSize, totalSize, dirSize);
+            await Client.DownloadDirectory(localDest, remoteSource, FtpFolderSyncMode.Update,
+                overwrite ? FtpLocalExists.Overwrite : FtpLocalExists.Skip, FtpVerify.None, null, adapter, ct);
+
+            long processed = processedSize + dirSize;
+            ReportProgress(progress, processed, totalSize);
+
+            if (delete)
+            {
+                await Client.DeleteDirectory(remoteSource, ct);
+            }
+            return processed;
+        }
+
+        public Task SearchAsync(string folder, string pattern, bool topOnly, bool searchContent,
+                                string contentText, IProgress<string> results,
+                                IProgress<string>? statusProgress, CancellationToken ct) =>
+            SearchCore(folder, pattern, topOnly, searchContent, contentText, results, statusProgress, ct);
+
+        private async Task SearchCore(string folder, string pattern, bool topOnly, bool searchContent,
+                                      string contentText, IProgress<string> results,
+                                      IProgress<string>? statusProgress, CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            statusProgress?.Report(folder);
+
+            FtpListItem[] listing;
+            try
+            {
+                listing = await Client.GetListing(RemotePath.GetRemotePart(folder), FtpListOption.Auto, ct);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "FTP search failed in {Folder}", folder);
+                return;
+            }
+
+            var regex = WildcardToRegex(pattern);
+            foreach (var item in listing)
+            {
+                ct.ThrowIfCancellationRequested();
+                if (item.Type == FtpObjectType.File && regex.IsMatch(item.Name))
+                {
+                    if (searchContent)
+                    {
+                        if (await FileContainsTextAsync(item.FullName, contentText, ct))
+                        {
+                            results.Report(RemotePath.Combine(item.FullName));
+                        }
+                    }
+                    else
+                    {
+                        results.Report(RemotePath.Combine(item.FullName));
+                    }
+                }
+                else if (item.Type == FtpObjectType.Directory && !searchContent && regex.IsMatch(item.Name))
+                {
+                    results.Report(RemotePath.Combine(item.FullName));
+                }
+            }
+
+            if (!topOnly)
+            {
+                foreach (var dir in listing.Where(i => i.Type == FtpObjectType.Directory))
+                {
+                    ct.ThrowIfCancellationRequested();
+                    await SearchCore(RemotePath.Combine(dir.FullName), pattern, topOnly, searchContent, contentText,
+                        results, statusProgress, ct);
+                }
+            }
+        }
+
+        private async Task<bool> FileContainsTextAsync(string remotePath, string contentText, CancellationToken ct)
+        {
+            try
+            {
+                var bytes = await Client.DownloadBytes(remotePath, ct);
+                return bytes != null && Encoding.UTF8.GetString(bytes).Contains(contentText);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        private static Regex WildcardToRegex(string pattern) =>
+            new("^" + Regex.Escape(pattern).Replace("\\*", ".*").Replace("\\?", ".") + "$",
+                RegexOptions.IgnoreCase);
+
+        public async Task<List<string>> GetDuplicatesAsync(IReadOnlyList<(string FullName, bool IsFolder)> items, string destPath)
+        {
+            var duplicates = new List<string>();
+            var destRemote = RemotePath.GetRemotePart(destPath);
+            foreach (var (fullName, isFolder) in items)
+            {
+                var targetRemote = CombineRemote(destRemote, Path.GetFileName(fullName));
+                if (isFolder)
+                {
+                    await CollectDuplicatesInDirectoryAsync(fullName, RemotePath.Combine(targetRemote), duplicates);
+                }
+                else if (await Client.FileExists(targetRemote))
+                {
+                    duplicates.Add(fullName);
+                }
+            }
+            return duplicates;
+        }
+
+        private async Task CollectDuplicatesInDirectoryAsync(string sourceDir, string destDir, List<string> duplicates)
+        {
+            if (!await DirectoryExistsAsync(sourceDir))
+            {
+                return;
+            }
+            var destRemote = RemotePath.GetRemotePart(destDir);
+            var filter = new DirectoryListingFilter();
+            foreach (var file in await GetFilesAsync(sourceDir, filter, CancellationToken.None))
+            {
+                var targetRemote = CombineRemote(destRemote, Path.GetFileName(file));
+                if (await Client.FileExists(targetRemote))
+                {
+                    duplicates.Add(file);
+                }
+            }
+            foreach (var dir in await GetDirectoriesAsync(sourceDir, filter, CancellationToken.None))
+            {
+                var targetSub = RemotePath.Combine(CombineRemote(destRemote, Path.GetFileName(dir)));
+                await CollectDuplicatesInDirectoryAsync(dir, targetSub, duplicates);
+            }
+        }
+
+        private static string CombineRemote(string basePart, string name) => basePart.TrimEnd('/') + "/" + name;
+
+        public async Task<List<string>> GetNonEmptyFoldersAsync(IReadOnlyList<(string FullName, bool IsFolder)> items)
+        {
+            var result = new List<string>();
+            if (!OptionsModel.Instance.ConfirmationWhenDeleteNonEmpty)
+            {
+                return result;
+            }
+            foreach (var (fullName, isFolder) in items)
+            {
+                if (!isFolder)
+                {
+                    continue;
+                }
+                var listing = await Client.GetListing(RemotePath.GetRemotePart(fullName), FtpListOption.Auto);
+                if (listing.Length > 0)
+                {
+                    result.Add(fullName);
+                }
+            }
+            return result;
+        }
+
+        private static long GetLocalDirectorySize(string path)
+        {
+            if (!Directory.Exists(path))
+            {
+                return 0;
+            }
+            long size = 0;
+            foreach (var file in Directory.EnumerateFiles(path, "*", SearchOption.AllDirectories))
+            {
+                try
+                {
+                    size += new FileInfo(file).Length;
+                }
+                catch (IOException)
+                {
+                }
+            }
+            return size;
+        }
+
+        private static void ReportProgress(IProgress<int>? progress, long processedSize, long totalSize)
+        {
+            if (progress == null)
+            {
+                return;
+            }
+            progress.Report(totalSize == 0 ? 0 : Convert.ToInt32(processedSize * 100 / totalSize));
+        }
+
+        // Adapts FluentFTP's per-item IProgress<FtpProgress> to the cumulative-across-the-whole-
+        // operation IProgress<int> (0-100) that FileOperationViewModel expects, matching
+        // LocalFileSystemProvider's processedSize/totalSize accumulation contract. Prefers
+        // FtpProgress.TransferredBytes (cumulative bytes for this transfer); falls back to
+        // Progress% scaled against a known item size (used for directory transfers, where
+        // TransferredBytes semantics are less reliable across multiple files).
+        private sealed class FtpProgressAdapter : IProgress<FtpProgress>
+        {
+            private readonly IProgress<int>? _progress;
+            private readonly long _baseProcessed;
+            private readonly long _totalSize;
+            private readonly long? _itemSize;
+
+            public FtpProgressAdapter(IProgress<int>? progress, long baseProcessed, long totalSize, long? itemSize = null)
+            {
+                _progress = progress;
+                _baseProcessed = baseProcessed;
+                _totalSize = totalSize;
+                _itemSize = itemSize;
+            }
+
+            public void Report(FtpProgress value)
+            {
+                if (_progress == null)
+                {
+                    return;
+                }
+
+                long processed;
+                if (value.TransferredBytes >= 0)
+                {
+                    processed = _baseProcessed + value.TransferredBytes;
+                }
+                else if (_itemSize is long itemSize && value.Progress >= 0)
+                {
+                    processed = _baseProcessed + (long)(itemSize * (value.Progress / 100.0));
+                }
+                else
+                {
+                    return;
+                }
+
+                processed = Math.Min(processed, _totalSize);
+                _progress.Report(_totalSize == 0 ? 0 : Convert.ToInt32(processed * 100 / _totalSize));
+            }
+        }
+    }
+}

--- a/src/SmartCommander/Services/FtpFileSystemProvider.cs
+++ b/src/SmartCommander/Services/FtpFileSystemProvider.cs
@@ -16,8 +16,16 @@ namespace SmartCommander.Services
     // the composite FileSystemService, created on connect, disposed on disconnect) since only
     // one FTP connection is ever active app-wide. All paths passed into this provider are full
     // "ftp://" strings (see RemotePath); FluentFTP only ever sees the remote part.
+    //
+    // A single FTP control connection can only run one command at a time - unlike local disk
+    // access, two commands issued concurrently on the same AsyncFtpClient corrupt the connection
+    // (garbled command/response state, spurious timeouts). Every method that touches the client
+    // acquires _lock first, so calls queue instead of interleaving; callers that used to run two
+    // requests in parallel against the local provider (e.g. listing files and folders together)
+    // now run them one after another here.
     public class FtpFileSystemProvider : IFileSystemProvider, IAsyncDisposable
     {
+        private readonly SemaphoreSlim _lock = new(1, 1);
         private AsyncFtpClient? _client;
 
         public string? Host { get; private set; }
@@ -60,21 +68,44 @@ namespace SmartCommander.Services
         private AsyncFtpClient Client =>
             _client ?? throw new InvalidOperationException("Not connected to an FTP server.");
 
-        public async Task<IReadOnlyList<string>> GetDirectoriesAsync(string path, DirectoryListingFilter filter, CancellationToken ct)
+        private async Task<T> LockedAsync<T>(CancellationToken ct, Func<Task<T>> action)
         {
-            var listing = await Client.GetListing(RemotePath.GetRemotePart(path), ToFtpListOption(filter), ct);
-            return listing
-                .Where(i => i.Type == FtpObjectType.Directory)
-                .Where(i => filter.IncludeHidden || !IsDotfile(i))
-                .Select(i => RemotePath.Combine(i.FullName))
-                .ToList();
+            await _lock.WaitAsync(ct);
+            try
+            {
+                return await action();
+            }
+            finally
+            {
+                _lock.Release();
+            }
         }
 
-        public async Task<IReadOnlyList<string>> GetFilesAsync(string path, DirectoryListingFilter filter, CancellationToken ct)
+        private async Task LockedAsync(CancellationToken ct, Func<Task> action)
+        {
+            await _lock.WaitAsync(ct);
+            try
+            {
+                await action();
+            }
+            finally
+            {
+                _lock.Release();
+            }
+        }
+
+        public Task<IReadOnlyList<string>> GetDirectoriesAsync(string path, DirectoryListingFilter filter, CancellationToken ct) =>
+            LockedAsync(ct, () => ListEntriesAsync(path, filter, FtpObjectType.Directory, ct));
+
+        public Task<IReadOnlyList<string>> GetFilesAsync(string path, DirectoryListingFilter filter, CancellationToken ct) =>
+            LockedAsync(ct, () => ListEntriesAsync(path, filter, FtpObjectType.File, ct));
+
+        // Raw, unlocked - only call from within a method that already holds _lock.
+        private async Task<IReadOnlyList<string>> ListEntriesAsync(string path, DirectoryListingFilter filter, FtpObjectType type, CancellationToken ct)
         {
             var listing = await Client.GetListing(RemotePath.GetRemotePart(path), ToFtpListOption(filter), ct);
             return listing
-                .Where(i => i.Type == FtpObjectType.File)
+                .Where(i => i.Type == type)
                 .Where(i => filter.IncludeHidden || !IsDotfile(i))
                 .Select(i => RemotePath.Combine(i.FullName))
                 .ToList();
@@ -99,10 +130,14 @@ namespace SmartCommander.Services
         }
 
         public Task<bool> DirectoryExistsAsync(string path, CancellationToken ct = default) =>
+            LockedAsync(ct, () => DirectoryExistsRawAsync(path, ct));
+
+        // Raw, unlocked - only call from within a method that already holds _lock.
+        private Task<bool> DirectoryExistsRawAsync(string path, CancellationToken ct) =>
             Client.DirectoryExists(RemotePath.GetRemotePart(path), ct);
 
         public Task<bool> FileExistsAsync(string path, CancellationToken ct = default) =>
-            Client.FileExists(RemotePath.GetRemotePart(path), ct);
+            LockedAsync(ct, () => Client.FileExists(RemotePath.GetRemotePart(path), ct));
 
         // Pure path math against the ftp:// scheme — no network call needed.
         public Task<string?> GetDirectoryParentAsync(string path, CancellationToken ct = default)
@@ -122,25 +157,27 @@ namespace SmartCommander.Services
             Task.FromResult<string?>(RemotePath.Combine("/"));
 
         public Task<long> GetFileSizeAsync(string path) =>
-            Client.GetFileSize(RemotePath.GetRemotePart(path));
+            LockedAsync(CancellationToken.None, () => Client.GetFileSize(RemotePath.GetRemotePart(path)));
 
         // FTP (via MDTM) only exposes a modified time, not a creation time; used as the
         // closest available approximation for FileViewModel's metadata display.
         public Task<DateTime> GetCreationTimeAsync(string path) =>
-            Client.GetModifiedTime(RemotePath.GetRemotePart(path));
+            LockedAsync(CancellationToken.None, () => Client.GetModifiedTime(RemotePath.GetRemotePart(path)));
 
-        public async Task<long> GetTotalSizeAsync(IReadOnlyList<(string FullName, bool IsFolder)> items)
-        {
-            long total = 0;
-            foreach (var (fullName, isFolder) in items)
+        public Task<long> GetTotalSizeAsync(IReadOnlyList<(string FullName, bool IsFolder)> items) =>
+            LockedAsync(CancellationToken.None, async () =>
             {
-                total += isFolder
-                    ? await GetDirectorySizeAsync(fullName)
-                    : await Client.GetFileSize(RemotePath.GetRemotePart(fullName));
-            }
-            return total;
-        }
+                long total = 0;
+                foreach (var (fullName, isFolder) in items)
+                {
+                    total += isFolder
+                        ? await GetDirectorySizeAsync(fullName)
+                        : await Client.GetFileSize(RemotePath.GetRemotePart(fullName));
+                }
+                return total;
+            });
 
+        // Raw, unlocked - only call from within a method that already holds _lock.
         private async Task<long> GetDirectorySizeAsync(string path)
         {
             var listing = await Client.GetListing(RemotePath.GetRemotePart(path), FtpListOption.Recursive, CancellationToken.None);
@@ -148,22 +185,22 @@ namespace SmartCommander.Services
         }
 
         public Task MoveFileAsync(string source, string dest) =>
-            Client.MoveFile(RemotePath.GetRemotePart(source), RemotePath.GetRemotePart(dest));
+            LockedAsync(CancellationToken.None, () => Client.MoveFile(RemotePath.GetRemotePart(source), RemotePath.GetRemotePart(dest)));
 
         public Task MoveDirectoryAsync(string source, string dest) =>
-            Client.MoveDirectory(RemotePath.GetRemotePart(source), RemotePath.GetRemotePart(dest));
+            LockedAsync(CancellationToken.None, () => Client.MoveDirectory(RemotePath.GetRemotePart(source), RemotePath.GetRemotePart(dest)));
 
         public Task RenameAsync(string oldPath, string newPath, bool isFolder) =>
-            Client.Rename(RemotePath.GetRemotePart(oldPath), RemotePath.GetRemotePart(newPath));
+            LockedAsync(CancellationToken.None, () => Client.Rename(RemotePath.GetRemotePart(oldPath), RemotePath.GetRemotePart(newPath)));
 
         public Task CreateDirectoryAsync(string path) =>
-            Client.CreateDirectory(RemotePath.GetRemotePart(path));
+            LockedAsync(CancellationToken.None, () => Client.CreateDirectory(RemotePath.GetRemotePart(path)));
 
         public Task DeleteFileAsync(string path) =>
-            Client.DeleteFile(RemotePath.GetRemotePart(path));
+            LockedAsync(CancellationToken.None, () => Client.DeleteFile(RemotePath.GetRemotePart(path)));
 
         public Task DeleteDirectoryAsync(string path, CancellationToken ct = default) =>
-            Client.DeleteDirectory(RemotePath.GetRemotePart(path), ct);
+            LockedAsync(ct, () => Client.DeleteDirectory(RemotePath.GetRemotePart(path), ct));
 
         // Required by IFileSystemProvider, but unreachable via the composite's dispatch:
         // FTP-to-FTP never occurs since at most one pane is ever FTP. Local<->FTP transfers
@@ -179,101 +216,106 @@ namespace SmartCommander.Services
             throw new NotSupportedException("FTP-to-FTP transfers are not supported.");
 
         // Called by the composite for a local -> FTP file transfer.
-        public async Task<long> UploadFileAsync(string localSource, string ftpDest, bool delete, bool overwrite,
-                                                 IProgress<int>? progress, long processedSize, long totalSize,
-                                                 CancellationToken ct)
-        {
-            var fileSize = new FileInfo(localSource).Length;
-            var existsMode = overwrite ? FtpRemoteExists.Overwrite : FtpRemoteExists.Skip;
-            var adapter = new FtpProgressAdapter(progress, processedSize, totalSize);
-            var status = await Client.UploadFile(localSource, RemotePath.GetRemotePart(ftpDest), existsMode,
-                false, FtpVerify.None, adapter, ct);
-
-            long processed = processedSize + (status == FtpStatus.Skipped ? 0 : fileSize);
-            ReportProgress(progress, processed, totalSize);
-
-            if (status != FtpStatus.Skipped && delete)
+        public Task<long> UploadFileAsync(string localSource, string ftpDest, bool delete, bool overwrite,
+                                           IProgress<int>? progress, long processedSize, long totalSize,
+                                           CancellationToken ct) =>
+            LockedAsync(ct, async () =>
             {
-                File.Delete(localSource);
-            }
-            return processed;
-        }
+                var fileSize = new FileInfo(localSource).Length;
+                var existsMode = overwrite ? FtpRemoteExists.Overwrite : FtpRemoteExists.Skip;
+                var adapter = new FtpProgressAdapter(progress, processedSize, totalSize);
+                var status = await Client.UploadFile(localSource, RemotePath.GetRemotePart(ftpDest), existsMode,
+                    false, FtpVerify.None, adapter, ct);
+
+                long processed = processedSize + (status == FtpStatus.Skipped ? 0 : fileSize);
+                ReportProgress(progress, processed, totalSize);
+
+                if (status != FtpStatus.Skipped && delete)
+                {
+                    File.Delete(localSource);
+                }
+                return processed;
+            });
 
         // Called by the composite for an FTP -> local file transfer.
-        public async Task<long> DownloadFileAsync(string ftpSource, string localDest, bool delete, bool overwrite,
-                                                   IProgress<int>? progress, long processedSize, long totalSize,
-                                                   CancellationToken ct)
-        {
-            var remoteSource = RemotePath.GetRemotePart(ftpSource);
-            var fileSize = Math.Max(0, await Client.GetFileSize(remoteSource, -1, ct));
-
-            if (!overwrite && File.Exists(localDest))
+        public Task<long> DownloadFileAsync(string ftpSource, string localDest, bool delete, bool overwrite,
+                                             IProgress<int>? progress, long processedSize, long totalSize,
+                                             CancellationToken ct) =>
+            LockedAsync(ct, async () =>
             {
-                long skipped = processedSize + fileSize;
-                ReportProgress(progress, skipped, totalSize);
-                return skipped;
-            }
+                var remoteSource = RemotePath.GetRemotePart(ftpSource);
+                var fileSize = Math.Max(0, await Client.GetFileSize(remoteSource, -1, ct));
 
-            var adapter = new FtpProgressAdapter(progress, processedSize, totalSize);
-            var status = await Client.DownloadFile(localDest, remoteSource, FtpLocalExists.Overwrite,
-                FtpVerify.None, adapter, ct);
+                if (!overwrite && File.Exists(localDest))
+                {
+                    long skipped = processedSize + fileSize;
+                    ReportProgress(progress, skipped, totalSize);
+                    return skipped;
+                }
 
-            long processed = processedSize + fileSize;
-            ReportProgress(progress, processed, totalSize);
+                var adapter = new FtpProgressAdapter(progress, processedSize, totalSize);
+                var status = await Client.DownloadFile(localDest, remoteSource, FtpLocalExists.Overwrite,
+                    FtpVerify.None, adapter, ct);
 
-            if (status == FtpStatus.Success && delete)
-            {
-                await Client.DeleteFile(remoteSource, ct);
-            }
-            return processed;
-        }
+                long processed = processedSize + fileSize;
+                ReportProgress(progress, processed, totalSize);
+
+                if (status == FtpStatus.Success && delete)
+                {
+                    await Client.DeleteFile(remoteSource, ct);
+                }
+                return processed;
+            });
 
         // Called by the composite for a local -> FTP directory transfer.
-        public async Task<long> UploadDirectoryAsync(string localSource, string ftpDest, bool delete, bool overwrite,
-                                                      IProgress<int>? progress, long processedSize, long totalSize,
-                                                      CancellationToken ct)
-        {
-            var dirSize = GetLocalDirectorySize(localSource);
-            var adapter = new FtpProgressAdapter(progress, processedSize, totalSize, dirSize);
-            await Client.UploadDirectory(localSource, RemotePath.GetRemotePart(ftpDest), FtpFolderSyncMode.Update,
-                overwrite ? FtpRemoteExists.Overwrite : FtpRemoteExists.Skip, FtpVerify.None, null, adapter, ct);
-
-            long processed = processedSize + dirSize;
-            ReportProgress(progress, processed, totalSize);
-
-            if (delete)
+        public Task<long> UploadDirectoryAsync(string localSource, string ftpDest, bool delete, bool overwrite,
+                                                IProgress<int>? progress, long processedSize, long totalSize,
+                                                CancellationToken ct) =>
+            LockedAsync(ct, async () =>
             {
-                Directory.Delete(localSource, true);
-            }
-            return processed;
-        }
+                var dirSize = GetLocalDirectorySize(localSource);
+                var adapter = new FtpProgressAdapter(progress, processedSize, totalSize, dirSize);
+                await Client.UploadDirectory(localSource, RemotePath.GetRemotePart(ftpDest), FtpFolderSyncMode.Update,
+                    overwrite ? FtpRemoteExists.Overwrite : FtpRemoteExists.Skip, FtpVerify.None, null, adapter, ct);
+
+                long processed = processedSize + dirSize;
+                ReportProgress(progress, processed, totalSize);
+
+                if (delete)
+                {
+                    Directory.Delete(localSource, true);
+                }
+                return processed;
+            });
 
         // Called by the composite for an FTP -> local directory transfer.
-        public async Task<long> DownloadDirectoryAsync(string ftpSource, string localDest, bool delete, bool overwrite,
-                                                        IProgress<int>? progress, long processedSize, long totalSize,
-                                                        CancellationToken ct)
-        {
-            var remoteSource = RemotePath.GetRemotePart(ftpSource);
-            var dirSize = await GetDirectorySizeAsync(ftpSource);
-            var adapter = new FtpProgressAdapter(progress, processedSize, totalSize, dirSize);
-            await Client.DownloadDirectory(localDest, remoteSource, FtpFolderSyncMode.Update,
-                overwrite ? FtpLocalExists.Overwrite : FtpLocalExists.Skip, FtpVerify.None, null, adapter, ct);
-
-            long processed = processedSize + dirSize;
-            ReportProgress(progress, processed, totalSize);
-
-            if (delete)
+        public Task<long> DownloadDirectoryAsync(string ftpSource, string localDest, bool delete, bool overwrite,
+                                                  IProgress<int>? progress, long processedSize, long totalSize,
+                                                  CancellationToken ct) =>
+            LockedAsync(ct, async () =>
             {
-                await Client.DeleteDirectory(remoteSource, ct);
-            }
-            return processed;
-        }
+                var remoteSource = RemotePath.GetRemotePart(ftpSource);
+                var dirSize = await GetDirectorySizeAsync(ftpSource);
+                var adapter = new FtpProgressAdapter(progress, processedSize, totalSize, dirSize);
+                await Client.DownloadDirectory(localDest, remoteSource, FtpFolderSyncMode.Update,
+                    overwrite ? FtpLocalExists.Overwrite : FtpLocalExists.Skip, FtpVerify.None, null, adapter, ct);
+
+                long processed = processedSize + dirSize;
+                ReportProgress(progress, processed, totalSize);
+
+                if (delete)
+                {
+                    await Client.DeleteDirectory(remoteSource, ct);
+                }
+                return processed;
+            });
 
         public Task SearchAsync(string folder, string pattern, bool topOnly, bool searchContent,
                                 string contentText, IProgress<string> results,
                                 IProgress<string>? statusProgress, CancellationToken ct) =>
-            SearchCore(folder, pattern, topOnly, searchContent, contentText, results, statusProgress, ct);
+            LockedAsync(ct, () => SearchCore(folder, pattern, topOnly, searchContent, contentText, results, statusProgress, ct));
 
+        // Raw, unlocked - only call from within a method that already holds _lock.
         private async Task SearchCore(string folder, string pattern, bool topOnly, bool searchContent,
                                       string contentText, IProgress<string> results,
                                       IProgress<string>? statusProgress, CancellationToken ct)
@@ -352,34 +394,36 @@ namespace SmartCommander.Services
             new("^" + Regex.Escape(pattern).Replace("\\*", ".*").Replace("\\?", ".") + "$",
                 RegexOptions.IgnoreCase);
 
-        public async Task<List<string>> GetDuplicatesAsync(IReadOnlyList<(string FullName, bool IsFolder)> items, string destPath)
-        {
-            var duplicates = new List<string>();
-            var destRemote = RemotePath.GetRemotePart(destPath);
-            foreach (var (fullName, isFolder) in items)
+        public Task<List<string>> GetDuplicatesAsync(IReadOnlyList<(string FullName, bool IsFolder)> items, string destPath) =>
+            LockedAsync(CancellationToken.None, async () =>
             {
-                var targetRemote = CombineRemote(destRemote, Path.GetFileName(fullName));
-                if (isFolder)
+                var duplicates = new List<string>();
+                var destRemote = RemotePath.GetRemotePart(destPath);
+                foreach (var (fullName, isFolder) in items)
                 {
-                    await CollectDuplicatesInDirectoryAsync(fullName, RemotePath.Combine(targetRemote), duplicates);
+                    var targetRemote = CombineRemote(destRemote, Path.GetFileName(fullName));
+                    if (isFolder)
+                    {
+                        await CollectDuplicatesInDirectoryAsync(fullName, RemotePath.Combine(targetRemote), duplicates);
+                    }
+                    else if (await Client.FileExists(targetRemote))
+                    {
+                        duplicates.Add(fullName);
+                    }
                 }
-                else if (await Client.FileExists(targetRemote))
-                {
-                    duplicates.Add(fullName);
-                }
-            }
-            return duplicates;
-        }
+                return duplicates;
+            });
 
+        // Raw, unlocked - only call from within a method that already holds _lock.
         private async Task CollectDuplicatesInDirectoryAsync(string sourceDir, string destDir, List<string> duplicates)
         {
-            if (!await DirectoryExistsAsync(sourceDir))
+            if (!await DirectoryExistsRawAsync(sourceDir, CancellationToken.None))
             {
                 return;
             }
             var destRemote = RemotePath.GetRemotePart(destDir);
             var filter = new DirectoryListingFilter();
-            foreach (var file in await GetFilesAsync(sourceDir, filter, CancellationToken.None))
+            foreach (var file in await ListEntriesAsync(sourceDir, filter, FtpObjectType.File, CancellationToken.None))
             {
                 var targetRemote = CombineRemote(destRemote, Path.GetFileName(file));
                 if (await Client.FileExists(targetRemote))
@@ -387,7 +431,7 @@ namespace SmartCommander.Services
                     duplicates.Add(file);
                 }
             }
-            foreach (var dir in await GetDirectoriesAsync(sourceDir, filter, CancellationToken.None))
+            foreach (var dir in await ListEntriesAsync(sourceDir, filter, FtpObjectType.Directory, CancellationToken.None))
             {
                 var targetSub = RemotePath.Combine(CombineRemote(destRemote, Path.GetFileName(dir)));
                 await CollectDuplicatesInDirectoryAsync(dir, targetSub, duplicates);
@@ -396,27 +440,28 @@ namespace SmartCommander.Services
 
         private static string CombineRemote(string basePart, string name) => basePart.TrimEnd('/') + "/" + name;
 
-        public async Task<List<string>> GetNonEmptyFoldersAsync(IReadOnlyList<(string FullName, bool IsFolder)> items)
-        {
-            var result = new List<string>();
-            if (!OptionsModel.Instance.ConfirmationWhenDeleteNonEmpty)
+        public Task<List<string>> GetNonEmptyFoldersAsync(IReadOnlyList<(string FullName, bool IsFolder)> items) =>
+            LockedAsync(CancellationToken.None, async () =>
             {
+                var result = new List<string>();
+                if (!OptionsModel.Instance.ConfirmationWhenDeleteNonEmpty)
+                {
+                    return result;
+                }
+                foreach (var (fullName, isFolder) in items)
+                {
+                    if (!isFolder)
+                    {
+                        continue;
+                    }
+                    var listing = await Client.GetListing(RemotePath.GetRemotePart(fullName), FtpListOption.Auto);
+                    if (listing.Length > 0)
+                    {
+                        result.Add(fullName);
+                    }
+                }
                 return result;
-            }
-            foreach (var (fullName, isFolder) in items)
-            {
-                if (!isFolder)
-                {
-                    continue;
-                }
-                var listing = await Client.GetListing(RemotePath.GetRemotePart(fullName), FtpListOption.Auto);
-                if (listing.Length > 0)
-                {
-                    result.Add(fullName);
-                }
-            }
-            return result;
-        }
+            });
 
         private static long GetLocalDirectorySize(string path)
         {

--- a/src/SmartCommander/Services/IFileSystemProvider.cs
+++ b/src/SmartCommander/Services/IFileSystemProvider.cs
@@ -14,6 +14,7 @@ namespace SmartCommander.Services
         Task<IReadOnlyList<string>> GetDirectoriesAsync(string path, DirectoryListingFilter filter, CancellationToken ct);
         Task<IReadOnlyList<string>> GetFilesAsync(string path, DirectoryListingFilter filter, CancellationToken ct);
         Task<bool> DirectoryExistsAsync(string path, CancellationToken ct = default);
+        Task<bool> FileExistsAsync(string path, CancellationToken ct = default);
         Task<string?> GetDirectoryParentAsync(string path, CancellationToken ct = default);
         Task<string?> GetPathRootAsync(string path, CancellationToken ct = default);
 

--- a/src/SmartCommander/Services/IFileSystemService.cs
+++ b/src/SmartCommander/Services/IFileSystemService.cs
@@ -1,9 +1,18 @@
+using System.Threading;
+using System.Threading.Tasks;
+
 namespace SmartCommander.Services
 {
-    // The single service ViewModels depend on. Same contract as IFileSystemProvider; the
-    // implementing composite (FileSystemService) routes each call to the provider that
-    // owns the path, so ViewModels stay unaware of which backend a path belongs to.
+    // The single service ViewModels depend on. Extends IFileSystemProvider with FTP connection
+    // management, which is a composite-level concern (no per-backend provider owns "which
+    // connection is active") rather than part of any one backend's contract. The implementing
+    // composite (FileSystemService) routes each IFileSystemProvider call to the provider that
+    // owns the path, so ViewModels otherwise stay unaware of which backend a path belongs to.
     public interface IFileSystemService : IFileSystemProvider
     {
+        bool IsFtpConnected { get; }
+        string? FtpHost { get; }
+        Task ConnectFtpAsync(string host, int port, string username, string password, bool anonymous, CancellationToken ct);
+        Task DisconnectFtpAsync();
     }
 }

--- a/src/SmartCommander/Services/IFileSystemService.cs
+++ b/src/SmartCommander/Services/IFileSystemService.cs
@@ -4,10 +4,9 @@ using System.Threading.Tasks;
 namespace SmartCommander.Services
 {
     // The single service ViewModels depend on. Extends IFileSystemProvider with FTP connection
-    // management, which is a composite-level concern (no per-backend provider owns "which
-    // connection is active") rather than part of any one backend's contract. The implementing
-    // composite (FileSystemService) routes each IFileSystemProvider call to the provider that
-    // owns the path, so ViewModels otherwise stay unaware of which backend a path belongs to.
+    // management, a composite-level concern since no per-backend provider owns "which connection
+    // is active". The implementing composite (FileSystemService) routes each call to the
+    // provider that owns the path, so ViewModels stay unaware of which backend a path belongs to.
     public interface IFileSystemService : IFileSystemProvider
     {
         bool IsFtpConnected { get; }

--- a/src/SmartCommander/Services/LocalFileSystemProvider.cs
+++ b/src/SmartCommander/Services/LocalFileSystemProvider.cs
@@ -35,6 +35,9 @@ namespace SmartCommander.Services
         public Task<bool> DirectoryExistsAsync(string path, CancellationToken ct = default) =>
             Task.Run(() => Directory.Exists(path), ct);
 
+        public Task<bool> FileExistsAsync(string path, CancellationToken ct = default) =>
+            Task.Run(() => File.Exists(path), ct);
+
         // Pure path math, no disk I/O — completes synchronously.
         public Task<string?> GetDirectoryParentAsync(string path, CancellationToken ct = default) =>
             Task.FromResult(Directory.GetParent(path)?.FullName);

--- a/src/SmartCommander/Services/RemotePath.cs
+++ b/src/SmartCommander/Services/RemotePath.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace SmartCommander.Services
+{
+    // Parses/formats the "ftp://" path scheme. No connection name is embedded in the path
+    // itself, since at most one FTP connection is ever active app-wide — there is never
+    // ambiguity about which connection a "ftp://" path refers to.
+    public static class RemotePath
+    {
+        public const string Scheme = "ftp://";
+
+        public static bool IsFtp(string path) =>
+            path.StartsWith(Scheme, StringComparison.OrdinalIgnoreCase);
+
+        // The path portion after "ftp://", always starting with '/'. Throws if not an ftp:// path.
+        public static string GetRemotePart(string path)
+        {
+            if (!IsFtp(path))
+            {
+                throw new ArgumentException($"Not an ftp:// path: {path}", nameof(path));
+            }
+            var remainder = path.Substring(Scheme.Length);
+            return remainder.StartsWith('/') ? remainder : "/" + remainder;
+        }
+
+        public static string Combine(string remotePart) =>
+            Scheme + (remotePart.StartsWith('/') ? remotePart : "/" + remotePart);
+
+        // Scheme-aware replacement for Path.Combine(basePath, name): a plain Path.Combine would
+        // join an "ftp://" base with the OS-native separator (backslash on Windows), producing a
+        // remote path FluentFTP can't resolve. Falls through to Path.Combine for local paths.
+        public static string CombineChild(string basePath, string name) =>
+            IsFtp(basePath)
+                ? Combine(GetRemotePart(basePath).TrimEnd('/') + "/" + name)
+                : System.IO.Path.Combine(basePath, name);
+    }
+}

--- a/src/SmartCommander/SmartCommander.csproj
+++ b/src/SmartCommander/SmartCommander.csproj
@@ -46,6 +46,7 @@
     <PackageReference Include="Avalonia.Desktop" Version="12.0.5" />
     <PackageReference Include="Avalonia.Controls.DataGrid" Version="12.0.1" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.5" />
+    <PackageReference Include="FluentFTP" Version="54.2.0" />
     <PackageReference Include="MessageBox.Avalonia" Version="12.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="ReactiveUI.Avalonia" Version="12.0.3" />

--- a/src/SmartCommander/ViewModels/FileViewModel.cs
+++ b/src/SmartCommander/ViewModels/FileViewModel.cs
@@ -92,7 +92,7 @@ namespace SmartCommander.ViewModels
                 var oldName = _name;
                 var oldFullName = _diskFullName;
                 var destName = IsFolder ? value : (value + (!string.IsNullOrEmpty(Extension) ? "." + Extension : ""));
-                var destination = Path.Combine(Path.GetDirectoryName(oldFullName) ?? "", destName);
+                var destination = RemotePath.CombineChild(Path.GetDirectoryName(oldFullName) ?? "", destName);
 
                 // Optimistic update so the DataGrid reflects the new name immediately
                 _name = value;

--- a/src/SmartCommander/ViewModels/FilesPaneViewModel.cs
+++ b/src/SmartCommander/ViewModels/FilesPaneViewModel.cs
@@ -553,7 +553,7 @@ namespace SmartCommander.ViewModels
 
         public async Task CreateNewFolder(string name)
         {
-            string newFolder = Path.Combine(CurrentDirectory, name);
+            string newFolder = RemotePath.CombineChild(CurrentDirectory, name);
             if (await _fs.DirectoryExistsAsync(newFolder))
             {
                 MessageBox_Show(null, Resources.FolderExists, Resources.Alert, ButtonEnum.Ok);
@@ -629,7 +629,8 @@ namespace SmartCommander.ViewModels
             string? selectedDrive;
             try
             {
-                if (!await _fs.DirectoryExistsAsync(dir, cts.Token) || !Path.IsPathFullyQualified(dir))
+                if (!await _fs.DirectoryExistsAsync(dir, cts.Token) ||
+                    (!RemotePath.IsFtp(dir) && !Path.IsPathFullyQualified(dir)))
                 {
                     return;
                 }
@@ -749,7 +750,9 @@ namespace SmartCommander.ViewModels
                 _pendingScrollTargetFullName = null;
             }
 
-            if (OperatingSystem.IsWindows())
+            // The drive combo is local-drives-only (menu-only FTP connect, no per-pane FTP UI);
+            // an ftp:// path has no drive to select there.
+            if (OperatingSystem.IsWindows() && !RemotePath.IsFtp(dir))
             {
                 SelectedDrive = selectedDrive;
             }

--- a/src/SmartCommander/ViewModels/FilesPaneViewModel.cs
+++ b/src/SmartCommander/ViewModels/FilesPaneViewModel.cs
@@ -622,6 +622,13 @@ namespace SmartCommander.ViewModels
                     CurrentDirectory = CurrentItem.FullName;
                 }
             }
+            else if (RemotePath.IsFtp(CurrentItem.FullName))
+            {
+                // UseShellExecute on an "ftp://" path hands it to the OS as a URL (opening a
+                // browser to a generic listing page) instead of launching a local application -
+                // there's no local file to open. Refuse instead of silently doing the wrong thing.
+                MessageBox_Show(null, Resources.CantOpenFtpFile, Resources.Alert, ButtonEnum.Ok);
+            }
             else
             {
                 // Callers discard the returned task, so a launch failure (e.g. no
@@ -679,7 +686,7 @@ namespace SmartCommander.ViewModels
             catch (Exception ex)
             {
                 Log.Error(ex, "Failed to load directory {Dir}", dir);
-                MessageBox_Show(null, string.Format(Resources.CantLoadDirectory, ex.Message), Resources.Alert);
+                MessageBox_Show(null, string.Format(Resources.CantLoadDirectory, DescribeException(ex)), Resources.Alert);
                 return;
             }
 
@@ -704,7 +711,7 @@ namespace SmartCommander.ViewModels
             catch (Exception ex)
             {
                 Log.Error(ex, "Failed to load directory {Dir}", dir);
-                MessageBox_Show(null, string.Format(Resources.CantLoadDirectory, ex.Message), Resources.Alert);
+                MessageBox_Show(null, string.Format(Resources.CantLoadDirectory, DescribeException(ex)), Resources.Alert);
                 return;
             }
 
@@ -729,7 +736,7 @@ namespace SmartCommander.ViewModels
             catch (Exception ex)
             {
                 Log.Error(ex, "Failed to build entries for {Dir}", dir);
-                MessageBox_Show(null, string.Format(Resources.CantLoadDirectory, ex.Message), Resources.Alert);
+                MessageBox_Show(null, string.Format(Resources.CantLoadDirectory, DescribeException(ex)), Resources.Alert);
                 return;
             }
 

--- a/src/SmartCommander/ViewModels/FilesPaneViewModel.cs
+++ b/src/SmartCommander/ViewModels/FilesPaneViewModel.cs
@@ -55,6 +55,7 @@ namespace SmartCommander.ViewModels
             {
                 _currentDirectory = value;
                 this.RaisePropertyChanged(nameof(CurrentDirectory));
+                this.RaisePropertyChanged(nameof(IsFtp));
                 _ = LoadDirectoryAsync(value);
             }
         }
@@ -73,6 +74,19 @@ namespace SmartCommander.ViewModels
         public List<FileViewModel> CurrentItems { get; set; } = new List<FileViewModel>();
 
         public bool IsUnzip => CurrentItems.Count > 0 && CurrentItems[0].Extension == "zip";
+
+        public bool IsFtp => RemotePath.IsFtp(CurrentDirectory);
+
+        private MainWindowViewModel.FtpTransferMenuMode TransferMenuMode =>
+            MainWindowViewModel.DetermineFtpTransferMenuMode(IsFtp, RemotePath.IsFtp(_mainVM.OtherPane(this).CurrentDirectory));
+
+        public bool ShowLocalCopyCut => TransferMenuMode == MainWindowViewModel.FtpTransferMenuMode.LocalClipboard;
+        public bool ShowDownload => TransferMenuMode == MainWindowViewModel.FtpTransferMenuMode.Download;
+        public bool ShowUpload => TransferMenuMode == MainWindowViewModel.FtpTransferMenuMode.Upload;
+
+        public bool ShowZip => !IsFtp && !IsUnzip;
+        public bool ShowUnzip => !IsFtp && IsUnzip;
+        public bool CanShowMoreOptions => !IsFtp && IsWindows;
 
         private bool _canPaste;
         public bool CanPaste
@@ -136,6 +150,7 @@ namespace SmartCommander.ViewModels
         public FilesPaneViewModel(MainWindowViewModel mainVM, EventHandler focusHandler, IFileSystemService fs)
         {
             _fs = fs;
+            _mainVM = mainVM;
             CurrentDirectory = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
             ViewCommand = ReactiveCommand.Create(View);
             EditCommand = ReactiveCommand.Create(Edit);
@@ -143,12 +158,13 @@ namespace SmartCommander.ViewModels
             UnzipCommand = ReactiveCommand.CreateFromTask(Unzip);
             CopyCommand = ReactiveCommand.CreateFromTask(Copy);
             CutCommand = ReactiveCommand.CreateFromTask(Cut);
+            TransferCommand = ReactiveCommand.CreateFromTask(() => _mainVM.Copy());
+            FtpMoveCommand = ReactiveCommand.CreateFromTask(() => _mainVM.Move());
             DeleteCommand = ReactiveCommand.CreateFromTask(Delete);
             PasteCommand = ReactiveCommand.CreateFromTask(Paste, this.WhenAnyValue(x => x.CanPaste));
             ShowMoreOptionsCommand = ReactiveCommand.CreateFromTask(ShowMoreOptions);
             ShowViewerDialog = new Interaction<ViewerViewModel, ViewerViewModel?>();
             ShowWindowsContextMenuInteraction = new Interaction<string[], Unit>();
-            _mainVM = mainVM;
             FocusChanged += focusHandler;
         }
 
@@ -165,6 +181,8 @@ namespace SmartCommander.ViewModels
         public ReactiveCommand<Unit, Unit>? UnzipCommand { get; }
         public ReactiveCommand<Unit, Unit>? CopyCommand { get; }
         public ReactiveCommand<Unit, Unit>? CutCommand { get; }
+        public ReactiveCommand<Unit, Unit>? TransferCommand { get; }
+        public ReactiveCommand<Unit, Unit>? FtpMoveCommand { get; }
         public ReactiveCommand<Unit, Unit>? DeleteCommand { get; }
         public ReactiveCommand<Unit, Unit>? PasteCommand { get; }
         public ReactiveCommand<Unit, Unit>? ShowMoreOptionsCommand { get; }
@@ -320,6 +338,11 @@ namespace SmartCommander.ViewModels
                 resultAction?.Invoke(ButtonResult.Ok, null);
                 return;
             }
+            if (IsFtp)
+            {
+                MessageBox_Show(resultAction, Resources.CantViewFtpFile, Resources.Alert, ButtonEnum.Ok);
+                return;
+            }
             if (!CurrentItem.IsFolder)
             {
                 if (ulong.TryParse(CurrentItem.Size, out var fileSize) && fileSize > 128 * 1024 * 1024)
@@ -347,6 +370,11 @@ namespace SmartCommander.ViewModels
             if (CurrentItem == null)
             {
                 resultAction?.Invoke(ButtonResult.Ok, null);
+                return;
+            }
+            if (IsFtp)
+            {
+                MessageBox_Show(resultAction, Resources.CantEditFtpFile, Resources.Alert, ButtonEnum.Ok);
                 return;
             }
             if (!CurrentItem.IsFolder)
@@ -648,6 +676,12 @@ namespace SmartCommander.ViewModels
             {
                 return;
             }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Failed to load directory {Dir}", dir);
+                MessageBox_Show(null, string.Format(Resources.CantLoadDirectory, ex.Message), Resources.Alert);
+                return;
+            }
 
             var filter = new DirectoryListingFilter(
                 IncludeHidden: OptionsModel.Instance.IsHiddenSystemFilesDisplayed,
@@ -670,6 +704,7 @@ namespace SmartCommander.ViewModels
             catch (Exception ex)
             {
                 Log.Error(ex, "Failed to load directory {Dir}", dir);
+                MessageBox_Show(null, string.Format(Resources.CantLoadDirectory, ex.Message), Resources.Alert);
                 return;
             }
 
@@ -694,6 +729,7 @@ namespace SmartCommander.ViewModels
             catch (Exception ex)
             {
                 Log.Error(ex, "Failed to build entries for {Dir}", dir);
+                MessageBox_Show(null, string.Format(Resources.CantLoadDirectory, ex.Message), Resources.Alert);
                 return;
             }
 

--- a/src/SmartCommander/ViewModels/FtpConnectViewModel.cs
+++ b/src/SmartCommander/ViewModels/FtpConnectViewModel.cs
@@ -1,0 +1,110 @@
+using Avalonia.Controls;
+using ReactiveUI;
+using SmartCommander.Models;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Reactive;
+
+namespace SmartCommander.ViewModels
+{
+    public class FtpConnectViewModel : ViewModelBase
+    {
+        public ObservableCollection<FtpConnectionProfile> SavedConnections { get; }
+
+        private FtpConnectionProfile? _selectedConnection;
+        public FtpConnectionProfile? SelectedConnection
+        {
+            get => _selectedConnection;
+            set
+            {
+                _selectedConnection = value;
+                this.RaisePropertyChanged(nameof(SelectedConnection));
+                if (value != null)
+                {
+                    Host = value.Host;
+                    Port = value.Port;
+                    Username = value.Username;
+                    Anonymous = value.Anonymous;
+                }
+            }
+        }
+
+        private string _host = "";
+        public string Host
+        {
+            get => _host;
+            set { _host = value; this.RaisePropertyChanged(nameof(Host)); }
+        }
+
+        private int _port = 21;
+        public int Port
+        {
+            get => _port;
+            set { _port = value; this.RaisePropertyChanged(nameof(Port)); }
+        }
+
+        private string _username = "";
+        public string Username
+        {
+            get => _username;
+            set { _username = value; this.RaisePropertyChanged(nameof(Username)); }
+        }
+
+        private string _password = "";
+        public string Password
+        {
+            get => _password;
+            set { _password = value; this.RaisePropertyChanged(nameof(Password)); }
+        }
+
+        private bool _anonymous;
+        public bool Anonymous
+        {
+            get => _anonymous;
+            set { _anonymous = value; this.RaisePropertyChanged(nameof(Anonymous)); }
+        }
+
+        public bool IsConfirmed { get; private set; }
+
+        public ReactiveCommand<Window, Unit> OKCommand { get; }
+        public ReactiveCommand<Window, Unit> CancelCommand { get; }
+
+        public FtpConnectViewModel()
+        {
+            SavedConnections = new ObservableCollection<FtpConnectionProfile>(FtpConnectionsModel.Instance.Connections);
+            OKCommand = ReactiveCommand.Create<Window>(SaveClose);
+            CancelCommand = ReactiveCommand.Create<Window>(Close);
+        }
+
+        private void SaveClose(Window window)
+        {
+            if (string.IsNullOrWhiteSpace(Host))
+            {
+                return;
+            }
+
+            var existing = FtpConnectionsModel.Instance.Connections.FirstOrDefault(c =>
+                c.Host == Host && c.Port == Port && c.Username == Username && c.Anonymous == Anonymous);
+            if (existing == null)
+            {
+                FtpConnectionsModel.Instance.Connections.Add(new FtpConnectionProfile
+                {
+                    Name = string.IsNullOrWhiteSpace(Username) ? Host : $"{Username}@{Host}",
+                    Host = Host,
+                    Port = Port,
+                    Username = Username,
+                    Anonymous = Anonymous
+                });
+                FtpConnectionsModel.Instance.Save();
+            }
+
+            IsConfirmed = true;
+            window?.Close(this);
+        }
+
+        private void Close(Window window)
+        {
+            window?.Close(this);
+        }
+    }
+}

--- a/src/SmartCommander/ViewModels/FtpConnectViewModel.cs
+++ b/src/SmartCommander/ViewModels/FtpConnectViewModel.cs
@@ -1,6 +1,7 @@
 using Avalonia.Controls;
 using ReactiveUI;
 using SmartCommander.Models;
+using System;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reactive;
@@ -71,7 +72,10 @@ namespace SmartCommander.ViewModels
 
         public FtpConnectViewModel()
         {
-            SavedConnections = new ObservableCollection<FtpConnectionProfile>(FtpConnectionsModel.Instance.Connections);
+            // Most-recently-used first, so a connection just used to reconnect (or a brand new
+            // one, saved with LastUsed set below) surfaces at the top next time the dialog opens.
+            SavedConnections = new ObservableCollection<FtpConnectionProfile>(
+                FtpConnectionsModel.Instance.Connections.OrderByDescending(c => c.LastUsed));
             OKCommand = ReactiveCommand.Create<Window>(SaveClose);
             CancelCommand = ReactiveCommand.Create<Window>(Close);
         }
@@ -83,6 +87,10 @@ namespace SmartCommander.ViewModels
                 return;
             }
 
+            // LastUsed is deliberately left unset here (default DateTime, sorts last) - it's only
+            // bumped by MainWindowViewModel.ConnectFtp once the connection actually succeeds, so
+            // a mistyped password or unreachable host doesn't move this profile to the top of the
+            // MRU dropdown.
             var existing = FtpConnectionsModel.Instance.Connections.FirstOrDefault(c =>
                 c.Host == Host && c.Port == Port && c.Username == Username && c.Anonymous == Anonymous);
             if (existing == null)

--- a/src/SmartCommander/ViewModels/MainWindowViewModel.cs
+++ b/src/SmartCommander/ViewModels/MainWindowViewModel.cs
@@ -765,7 +765,7 @@ namespace SmartCommander.ViewModels
                     catch (Exception ex)
                     {
                         MessageBox_Show(null, string.Format(
-                            move ? Resources.CantMoveFolderHere : Resources.CantCopyFolderHere, ex.Message), Resources.Alert);
+                            move ? Resources.CantMoveFolderHere : Resources.CantCopyFolderHere, DescribeException(ex)), Resources.Alert);
                         throw new IOException($"Can't {(move ? "move" : "copy")} folder {fullName}", ex);
                     }
                 }
@@ -782,7 +782,7 @@ namespace SmartCommander.ViewModels
                     catch (Exception ex)
                     {
                         MessageBox_Show(null, string.Format(
-                            move ? Resources.CantMoveFileHere : Resources.CantCopyFileHere, ex.Message), Resources.Alert);
+                            move ? Resources.CantMoveFileHere : Resources.CantCopyFileHere, DescribeException(ex)), Resources.Alert);
                         throw new IOException($"Can't {(move ? "move" : "copy")} file {fullName}", ex);
                     }
                 }
@@ -836,8 +836,19 @@ namespace SmartCommander.ViewModels
             catch (Exception ex)
             {
                 Log.Error(ex, "FTP connect failed for {Host}", result.Host);
-                MessageBox_Show(null, string.Format(Resources.FtpConnectionFailed, ex.Message), Resources.Alert, ButtonEnum.Ok);
+                MessageBox_Show(null, string.Format(Resources.FtpConnectionFailed, DescribeException(ex)), Resources.Alert, ButtonEnum.Ok);
                 return;
+            }
+
+            // Bumped here rather than on dialog OK-click, so a mistyped password or unreachable
+            // host doesn't move that profile to the top of the MRU dropdown ahead of profiles
+            // that have actually connected successfully.
+            var profile = FtpConnectionsModel.Instance.Connections.FirstOrDefault(c =>
+                c.Host == result.Host && c.Port == result.Port && c.Username == result.Username && c.Anonymous == result.Anonymous);
+            if (profile != null)
+            {
+                profile.LastUsed = DateTime.Now;
+                FtpConnectionsModel.Instance.Save();
             }
 
             this.RaisePropertyChanged(nameof(IsFtpConnected));
@@ -998,7 +1009,7 @@ namespace SmartCommander.ViewModels
                 catch (Exception ex)
                 {
                     MessageBox_Show(null, string.Format(
-                        isFolder ? Resources.CantDeleteFolderHere : Resources.CantDeleteFileHere, ex.Message), Resources.Alert);
+                        isFolder ? Resources.CantDeleteFolderHere : Resources.CantDeleteFileHere, DescribeException(ex)), Resources.Alert);
                     throw new IOException($"Can't delete {(isFolder ? "folder" : "file")} {fullName}", ex);
                 }
                 done++;

--- a/src/SmartCommander/ViewModels/MainWindowViewModel.cs
+++ b/src/SmartCommander/ViewModels/MainWindowViewModel.cs
@@ -58,7 +58,7 @@ namespace SmartCommander.ViewModels
             OptionsCommand = ReactiveCommand.CreateFromTask(ShowOptions);
             AboutCommand = ReactiveCommand.CreateFromTask(ShowAbout);
 
-            ConnectFtpCommand = ReactiveCommand.CreateFromTask(ConnectFtp);
+            ConnectFtpCommand = ReactiveCommand.CreateFromTask(ConnectFtp, this.WhenAnyValue(x => x.IsFtpConnected).Select(c => !c));
             DisconnectFtpCommand = ReactiveCommand.CreateFromTask(DisconnectFtp, this.WhenAnyValue(x => x.IsFtpConnected));
 
             LeftFileViewModel = new FilesPaneViewModel(this, OnFocusChanged, _fs);
@@ -213,6 +213,9 @@ namespace SmartCommander.ViewModels
                 }
             }
         }
+
+        internal FilesPaneViewModel OtherPane(FilesPaneViewModel pane) =>
+            pane == LeftFileViewModel ? RightFileViewModel : LeftFileViewModel;
 
         private FilesPaneViewModel _selectedPane = null!;
         public FilesPaneViewModel SelectedPane
@@ -761,7 +764,8 @@ namespace SmartCommander.ViewModels
                     catch (OperationCanceledException) { throw; }
                     catch (Exception ex)
                     {
-                        MessageBox_Show(null, move ? Resources.CantMoveFolderHere : Resources.CantCopyFolderHere, Resources.Alert);
+                        MessageBox_Show(null, string.Format(
+                            move ? Resources.CantMoveFolderHere : Resources.CantCopyFolderHere, ex.Message), Resources.Alert);
                         throw new IOException($"Can't {(move ? "move" : "copy")} folder {fullName}", ex);
                     }
                 }
@@ -777,7 +781,8 @@ namespace SmartCommander.ViewModels
                     catch (OperationCanceledException) { throw; }
                     catch (Exception ex)
                     {
-                        MessageBox_Show(null, move ? Resources.CantMoveFileHere : Resources.CantCopyFileHere, Resources.Alert);
+                        MessageBox_Show(null, string.Format(
+                            move ? Resources.CantMoveFileHere : Resources.CantCopyFileHere, ex.Message), Resources.Alert);
                         throw new IOException($"Can't {(move ? "move" : "copy")} file {fullName}", ex);
                     }
                 }
@@ -814,7 +819,7 @@ namespace SmartCommander.ViewModels
             // At most one FTP connection is ever active app-wide; if the other pane currently
             // shows it, navigate it back to local first so it isn't left pointing at a
             // connection that's about to be replaced.
-            var otherPane = SelectedPane == LeftFileViewModel ? RightFileViewModel : LeftFileViewModel;
+            var otherPane = OtherPane(SelectedPane);
             if (RemotePath.IsFtp(otherPane.CurrentDirectory))
             {
                 otherPane.CurrentDirectory = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
@@ -822,7 +827,11 @@ namespace SmartCommander.ViewModels
 
             try
             {
-                await _fs.ConnectFtpAsync(result.Host, result.Port, result.Username, result.Password, result.Anonymous, CancellationToken.None);
+                // A hung/unresponsive server (or a firewall silently dropping the connection
+                // attempt) would otherwise block the connect dialog forever with no feedback
+                // and no way to cancel - bound it instead of passing CancellationToken.None.
+                using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+                await _fs.ConnectFtpAsync(result.Host, result.Port, result.Username, result.Password, result.Anonymous, cts.Token);
             }
             catch (Exception ex)
             {
@@ -974,17 +983,44 @@ namespace SmartCommander.ViewModels
             foreach (var (fullName, isFolder) in items)
             {
                 ct.ThrowIfCancellationRequested();
-                if (isFolder)
+                try
                 {
-                    await _fs.DeleteDirectoryAsync(fullName, ct);
+                    if (isFolder)
+                    {
+                        await _fs.DeleteDirectoryAsync(fullName, ct);
+                    }
+                    else
+                    {
+                        await _fs.DeleteFileAsync(fullName);
+                    }
                 }
-                else
+                catch (OperationCanceledException) { throw; }
+                catch (Exception ex)
                 {
-                    await _fs.DeleteFileAsync(fullName);
+                    MessageBox_Show(null, string.Format(
+                        isFolder ? Resources.CantDeleteFolderHere : Resources.CantDeleteFileHere, ex.Message), Resources.Alert);
+                    throw new IOException($"Can't delete {(isFolder ? "folder" : "file")} {fullName}", ex);
                 }
                 done++;
                 progress.Report(done * 100 / total);
             }
+        }
+
+        internal enum FtpTransferMenuMode { LocalClipboard, Download, Upload }
+
+        // At most one FTP connection is ever active app-wide, so a pane is never both
+        // "the FTP pane" and "the other pane while FTP is active" at once.
+        internal static FtpTransferMenuMode DetermineFtpTransferMenuMode(bool paneIsFtp, bool otherPaneIsFtp)
+        {
+            if (paneIsFtp)
+            {
+                return FtpTransferMenuMode.Download;
+            }
+            if (otherPaneIsFtp)
+            {
+                return FtpTransferMenuMode.Upload;
+            }
+            return FtpTransferMenuMode.LocalClipboard;
         }
 
         internal static bool IsDestinationInsideSource(string sourceFolder, string destination)

--- a/src/SmartCommander/ViewModels/MainWindowViewModel.cs
+++ b/src/SmartCommander/ViewModels/MainWindowViewModel.cs
@@ -34,6 +34,7 @@ namespace SmartCommander.ViewModels
             ShowOptionsDialog = new Interaction<OptionsViewModel, OptionsViewModel?>();
             ShowSearchDialog = new Interaction<FileSearchViewModel, FileSearchViewModel?>();
             ShowAboutDialog = new Interaction<AboutViewModel, AboutViewModel?>();
+            ShowFtpConnectDialog = new Interaction<FtpConnectViewModel, FtpConnectViewModel?>();
 
             ExitCommand = ReactiveCommand.Create(Exit);
             SortNameCommand = ReactiveCommand.Create(SortName);
@@ -57,15 +58,21 @@ namespace SmartCommander.ViewModels
             OptionsCommand = ReactiveCommand.CreateFromTask(ShowOptions);
             AboutCommand = ReactiveCommand.CreateFromTask(ShowAbout);
 
+            ConnectFtpCommand = ReactiveCommand.CreateFromTask(ConnectFtp);
+            DisconnectFtpCommand = ReactiveCommand.CreateFromTask(DisconnectFtp, this.WhenAnyValue(x => x.IsFtpConnected));
+
             LeftFileViewModel = new FilesPaneViewModel(this, OnFocusChanged, _fs);
             RightFileViewModel = new FilesPaneViewModel(this, OnFocusChanged, _fs);
             SelectedPane = RightFileViewModel;
 
-            if (!string.IsNullOrEmpty(OptionsModel.Instance.LeftPanePath))
+            // A saved ftp:// path has no live connection behind it on startup - FTP sessions
+            // aren't persisted across restart - so skip it and fall through to the pane's own
+            // default directory instead of silently trying to reconnect with no credentials.
+            if (!string.IsNullOrEmpty(OptionsModel.Instance.LeftPanePath) && !RemotePath.IsFtp(OptionsModel.Instance.LeftPanePath))
             {
                 LeftFileViewModel.CurrentDirectory = OptionsModel.Instance.LeftPanePath;
             }
-            if (!string.IsNullOrEmpty(OptionsModel.Instance.RightPanePath))
+            if (!string.IsNullOrEmpty(OptionsModel.Instance.RightPanePath) && !RemotePath.IsFtp(OptionsModel.Instance.RightPanePath))
             {
                 RightFileViewModel.CurrentDirectory = OptionsModel.Instance.RightPanePath;
             }
@@ -112,6 +119,11 @@ namespace SmartCommander.ViewModels
         public ReactiveCommand<Unit, Unit> OptionsCommand { get; }
         public ReactiveCommand<Unit, Unit> AboutCommand { get; }
 
+        public ReactiveCommand<Unit, Unit> ConnectFtpCommand { get; }
+        public ReactiveCommand<Unit, Unit> DisconnectFtpCommand { get; }
+
+        public bool IsFtpConnected => _fs.IsFtpConnected;
+
         public FilesPaneViewModel LeftFileViewModel { get; }
 
         public FilesPaneViewModel RightFileViewModel { get; }
@@ -137,6 +149,7 @@ namespace SmartCommander.ViewModels
         public Interaction<OptionsViewModel, OptionsViewModel?> ShowOptionsDialog { get; }
         public Interaction<FileSearchViewModel, FileSearchViewModel?> ShowSearchDialog { get; }
         public Interaction<AboutViewModel, AboutViewModel?> ShowAboutDialog { get; }
+        public Interaction<FtpConnectViewModel, FtpConnectViewModel?> ShowFtpConnectDialog { get; }
 
         public static bool IsFunctionKeysDisplayed => OptionsModel.Instance.IsFunctionKeysDisplayed;
         public static bool IsCommandLineDisplayed => OptionsModel.Instance.IsCommandLineDisplayed;
@@ -720,7 +733,7 @@ namespace SmartCommander.ViewModels
                 {
                     try
                     {
-                        string destFolder = Path.Combine(destDirectory, Path.GetFileName(fullName));
+                        string destFolder = RemotePath.CombineChild(destDirectory, Path.GetFileName(fullName));
                         if (move)
                         {
                             bool sameDrive = string.Equals(
@@ -756,7 +769,7 @@ namespace SmartCommander.ViewModels
                 {
                     try
                     {
-                        string destFile = Path.Combine(destDirectory, Path.GetFileName(fullName));
+                        string destFile = RemotePath.CombineChild(destDirectory, Path.GetFileName(fullName));
                         processedSize = await _fs.CopyFileAsync(
                             fullName, destFile, move, overwrite,
                             progress, processedSize, totalSize, ct);
@@ -788,6 +801,53 @@ namespace SmartCommander.ViewModels
         public async Task ShowAbout()
         {
             await ShowAboutDialog.Handle(new AboutViewModel());
+        }
+
+        public async Task ConnectFtp()
+        {
+            var result = await ShowFtpConnectDialog.Handle(new FtpConnectViewModel());
+            if (result == null || !result.IsConfirmed)
+            {
+                return;
+            }
+
+            // At most one FTP connection is ever active app-wide; if the other pane currently
+            // shows it, navigate it back to local first so it isn't left pointing at a
+            // connection that's about to be replaced.
+            var otherPane = SelectedPane == LeftFileViewModel ? RightFileViewModel : LeftFileViewModel;
+            if (RemotePath.IsFtp(otherPane.CurrentDirectory))
+            {
+                otherPane.CurrentDirectory = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
+            }
+
+            try
+            {
+                await _fs.ConnectFtpAsync(result.Host, result.Port, result.Username, result.Password, result.Anonymous, CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "FTP connect failed for {Host}", result.Host);
+                MessageBox_Show(null, string.Format(Resources.FtpConnectionFailed, ex.Message), Resources.Alert, ButtonEnum.Ok);
+                return;
+            }
+
+            this.RaisePropertyChanged(nameof(IsFtpConnected));
+            SelectedPane.CurrentDirectory = RemotePath.Combine("/");
+        }
+
+        public async Task DisconnectFtp()
+        {
+            var localHome = Environment.GetFolderPath(Environment.SpecialFolder.Personal);
+            if (RemotePath.IsFtp(LeftFileViewModel.CurrentDirectory))
+            {
+                LeftFileViewModel.CurrentDirectory = localHome;
+            }
+            if (RemotePath.IsFtp(RightFileViewModel.CurrentDirectory))
+            {
+                RightFileViewModel.CurrentDirectory = localHome;
+            }
+            await _fs.DisconnectFtpAsync();
+            this.RaisePropertyChanged(nameof(IsFtpConnected));
         }
 
         private void SetTheme()

--- a/src/SmartCommander/ViewModels/ViewModelBase.cs
+++ b/src/SmartCommander/ViewModels/ViewModelBase.cs
@@ -5,6 +5,7 @@ using MsBox.Avalonia.Enums;
 using ReactiveUI;
 using SmartCommander.Views;
 using System;
+using System.Collections.Generic;
 
 namespace SmartCommander.ViewModels
 {
@@ -36,9 +37,24 @@ namespace SmartCommander.ViewModels
         {
             if (this.MessageBoxInputRequest != null)
             {
-                this.MessageBoxInputRequest(this, new MvvmMessageBoxEventArgs(null, resultAction, messageBoxText, 
+                this.MessageBoxInputRequest(this, new MvvmMessageBoxEventArgs(null, resultAction, messageBoxText,
                     caption, ButtonEnum.OkCancel));
             }
+        }
+
+        // ex.Message alone is often just a wrapper like FluentFTP's "See InnerException for more
+        // info." - walk the chain so the actual server/network reason reaches the message box.
+        protected static string DescribeException(Exception ex)
+        {
+            var messages = new List<string>();
+            for (var e = ex; e != null; e = e.InnerException)
+            {
+                if (!string.IsNullOrWhiteSpace(e.Message) && !messages.Contains(e.Message))
+                {
+                    messages.Add(e.Message);
+                }
+            }
+            return string.Join(" ", messages);
         }
     }
 }

--- a/src/SmartCommander/Views/FilesPane.axaml
+++ b/src/SmartCommander/Views/FilesPane.axaml
@@ -39,7 +39,7 @@
 				<MenuItem Header="{x:Static assets:Resources.Paste}"
 						  Command="{Binding PasteCommand}" />
 				<MenuItem Header="{x:Static assets:Resources.MoreOptions}"
-						  IsVisible="{Binding IsWindows}"
+						  IsVisible="{Binding CanShowMoreOptions}"
 						  Command="{Binding ShowMoreOptionsCommand}" />
 			</MenuFlyout>
 		</Grid.ContextFlyout>
@@ -50,12 +50,13 @@
 				<ColumnDefinition Width="Auto"/>
 			</Grid.ColumnDefinitions>
 
-			<TextBox IsTabStop="False" Text="{Binding CurrentDirectory}" />
+			<TextBox IsTabStop="False" Text="{Binding CurrentDirectory}" IsEnabled="{Binding !IsFtp}" />
 			<ComboBox Grid.Column="1"
                       IsVisible="{Binding IsWindows}"
                       Name="driveCombo"
                       SelectedItem="{Binding SelectedDrive, Mode=TwoWay}"
-                      IsTabStop="False"/>
+                      IsTabStop="False"
+                      IsEnabled="{Binding !IsFtp}"/>
 		</Grid>
 
 		<DataGrid Name="PaneDataGrid"
@@ -88,17 +89,30 @@
 				<MenuFlyout>
 					<MenuItem Header="{x:Static assets:Resources.View}" Command="{Binding ViewCommand}" />
 					<MenuItem Header="{x:Static assets:Resources.Edit}" Command="{Binding EditCommand}" />
-					<MenuItem Header="{x:Static assets:Resources.Copy}" Command="{Binding CopyCommand}" />
-					<MenuItem Header="{x:Static assets:Resources.Cut}" Command="{Binding CutCommand}" />
+					<MenuItem Header="{x:Static assets:Resources.Copy}"
+                              IsVisible="{Binding ShowLocalCopyCut}"
+                              Command="{Binding CopyCommand}" />
+					<MenuItem Header="{x:Static assets:Resources.Cut}"
+                              IsVisible="{Binding ShowLocalCopyCut}"
+                              Command="{Binding CutCommand}" />
+					<MenuItem Header="{x:Static assets:Resources.Download}"
+                              IsVisible="{Binding ShowDownload}"
+                              Command="{Binding TransferCommand}" />
+					<MenuItem Header="{x:Static assets:Resources.Upload}"
+                              IsVisible="{Binding ShowUpload}"
+                              Command="{Binding TransferCommand}" />
+					<MenuItem Header="{x:Static assets:Resources.Move}"
+                              IsVisible="{Binding !ShowLocalCopyCut}"
+                              Command="{Binding FtpMoveCommand}" />
 					<MenuItem Header="{x:Static assets:Resources.Delete}" Command="{Binding DeleteCommand}" />
 					<MenuItem Header="{x:Static assets:Resources.Zip}"
-                              IsVisible="{Binding !IsUnzip, Mode=TwoWay}"
+                              IsVisible="{Binding ShowZip, Mode=TwoWay}"
                               Command="{Binding ZipCommand}" />
 					<MenuItem Header="{x:Static assets:Resources.Unzip}"
-                              IsVisible="{Binding IsUnzip, Mode=TwoWay}"
+                              IsVisible="{Binding ShowUnzip, Mode=TwoWay}"
                               Command="{Binding UnzipCommand}" />
 					<MenuItem Header="{x:Static assets:Resources.MoreOptions}"
-                              IsVisible="{Binding IsWindows}"
+                              IsVisible="{Binding CanShowMoreOptions}"
                               Command="{Binding ShowMoreOptionsCommand}" />
 				</MenuFlyout>
 			</DataGrid.ContextFlyout>

--- a/src/SmartCommander/Views/FtpConnectWindow.axaml
+++ b/src/SmartCommander/Views/FtpConnectWindow.axaml
@@ -1,0 +1,53 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:CompileBindings="False"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d" d:DesignWidth="380" d:DesignHeight="340"
+        Width="380" Height="340"
+        x:Class="SmartCommander.Views.FtpConnectWindow"
+        WindowStartupLocation="CenterOwner"
+        ShowInTaskbar="False"
+        xmlns:assets="clr-namespace:SmartCommander.Assets"
+        Icon="/Assets/main.ico"
+        CanResize="False"
+        Title="{x:Static assets:Resources.FtpConnectTitle}">
+	<Grid Margin="15">
+		<Grid.RowDefinitions>
+			<RowDefinition Height="*"/>
+			<RowDefinition Height="Auto"/>
+		</Grid.RowDefinitions>
+		<StackPanel Grid.Row="0" Spacing="6">
+			<TextBlock Text="{x:Static assets:Resources.FtpSavedConnections}"/>
+			<ComboBox ItemsSource="{Binding SavedConnections}" SelectedItem="{Binding SelectedConnection, Mode=TwoWay}"
+					  HorizontalAlignment="Stretch">
+				<ComboBox.ItemTemplate>
+					<DataTemplate>
+						<TextBlock Text="{Binding Name}"/>
+					</DataTemplate>
+				</ComboBox.ItemTemplate>
+			</ComboBox>
+
+			<TextBlock Text="{x:Static assets:Resources.FtpHost}" Margin="0,8,0,0"/>
+			<TextBox Text="{Binding Host, Mode=TwoWay}" Name="HostTextBox"/>
+
+			<TextBlock Text="{x:Static assets:Resources.FtpPort}"/>
+			<NumericUpDown Value="{Binding Port, Mode=TwoWay}" Minimum="1" Maximum="65535" FormatString="0"/>
+
+			<CheckBox IsChecked="{Binding Anonymous, Mode=TwoWay}" Content="{x:Static assets:Resources.FtpAnonymous}"/>
+
+			<TextBlock Text="{x:Static assets:Resources.FtpUsername}" IsEnabled="{Binding !Anonymous}"/>
+			<TextBox Text="{Binding Username, Mode=TwoWay}" IsEnabled="{Binding !Anonymous}"/>
+
+			<TextBlock Text="{x:Static assets:Resources.FtpPassword}" IsEnabled="{Binding !Anonymous}"/>
+			<TextBox Text="{Binding Password, Mode=TwoWay}" PasswordChar="●" IsEnabled="{Binding !Anonymous}"/>
+		</StackPanel>
+
+		<StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+			<Button Margin="5" Command="{Binding OKCommand}" CommandParameter="{Binding $parent[Window]}" IsDefault="True"
+					Content="{x:Static assets:Resources.FtpConnectButton}"/>
+			<Button Margin="5" Command="{Binding CancelCommand}" CommandParameter="{Binding $parent[Window]}" IsCancel="True"
+					Content="{x:Static assets:Resources.Cancel}"/>
+		</StackPanel>
+	</Grid>
+</Window>

--- a/src/SmartCommander/Views/FtpConnectWindow.axaml
+++ b/src/SmartCommander/Views/FtpConnectWindow.axaml
@@ -3,8 +3,8 @@
         x:CompileBindings="False"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        mc:Ignorable="d" d:DesignWidth="380" d:DesignHeight="340"
-        Width="380" Height="340"
+        mc:Ignorable="d" d:DesignWidth="460" d:DesignHeight="360"
+        Width="460" Height="360"
         x:Class="SmartCommander.Views.FtpConnectWindow"
         WindowStartupLocation="CenterOwner"
         ShowInTaskbar="False"
@@ -14,36 +14,54 @@
         Title="{x:Static assets:Resources.FtpConnectTitle}">
 	<Grid Margin="15">
 		<Grid.RowDefinitions>
-			<RowDefinition Height="*"/>
 			<RowDefinition Height="Auto"/>
+			<RowDefinition Height="Auto"/>
+			<RowDefinition Height="Auto"/>
+			<RowDefinition Height="Auto"/>
+			<RowDefinition Height="Auto"/>
+			<RowDefinition Height="Auto"/>
+			<RowDefinition Height="*"/>
 		</Grid.RowDefinitions>
-		<StackPanel Grid.Row="0" Spacing="6">
-			<TextBlock Text="{x:Static assets:Resources.FtpSavedConnections}"/>
-			<ComboBox ItemsSource="{Binding SavedConnections}" SelectedItem="{Binding SelectedConnection, Mode=TwoWay}"
-					  HorizontalAlignment="Stretch">
-				<ComboBox.ItemTemplate>
-					<DataTemplate>
-						<TextBlock Text="{Binding Name}"/>
-					</DataTemplate>
-				</ComboBox.ItemTemplate>
-			</ComboBox>
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="Auto"/>
+			<ColumnDefinition Width="*"/>
+		</Grid.ColumnDefinitions>
 
-			<TextBlock Text="{x:Static assets:Resources.FtpHost}" Margin="0,8,0,0"/>
-			<TextBox Text="{Binding Host, Mode=TwoWay}" Name="HostTextBox"/>
+		<TextBlock Grid.Row="0" Grid.Column="0" Margin="0,0,10,10" VerticalAlignment="Center"
+				   Text="{x:Static assets:Resources.FtpSavedConnections}"/>
+		<ComboBox Grid.Row="0" Grid.Column="1" Margin="0,0,0,10" HorizontalAlignment="Stretch"
+				  ItemsSource="{Binding SavedConnections}" SelectedItem="{Binding SelectedConnection, Mode=TwoWay}">
+			<ComboBox.ItemTemplate>
+				<DataTemplate>
+					<TextBlock Text="{Binding Name}"/>
+				</DataTemplate>
+			</ComboBox.ItemTemplate>
+		</ComboBox>
 
-			<TextBlock Text="{x:Static assets:Resources.FtpPort}"/>
-			<NumericUpDown Value="{Binding Port, Mode=TwoWay}" Minimum="1" Maximum="65535" FormatString="0"/>
+		<TextBlock Grid.Row="1" Grid.Column="0" Margin="0,0,10,10" VerticalAlignment="Center"
+				   Text="{x:Static assets:Resources.FtpHost}"/>
+		<TextBox Grid.Row="1" Grid.Column="1" Margin="0,0,0,10" Text="{Binding Host, Mode=TwoWay}" Name="HostTextBox"/>
 
-			<CheckBox IsChecked="{Binding Anonymous, Mode=TwoWay}" Content="{x:Static assets:Resources.FtpAnonymous}"/>
+		<TextBlock Grid.Row="2" Grid.Column="0" Margin="0,0,10,10" VerticalAlignment="Center"
+				   Text="{x:Static assets:Resources.FtpPort}"/>
+		<NumericUpDown Grid.Row="2" Grid.Column="1" Margin="0,0,0,10" HorizontalAlignment="Stretch"
+					   Value="{Binding Port, Mode=TwoWay}" Minimum="1" Maximum="65535" FormatString="0"/>
 
-			<TextBlock Text="{x:Static assets:Resources.FtpUsername}" IsEnabled="{Binding !Anonymous}"/>
-			<TextBox Text="{Binding Username, Mode=TwoWay}" IsEnabled="{Binding !Anonymous}"/>
+		<CheckBox Grid.Row="3" Grid.Column="1" Margin="0,0,0,10"
+				  IsChecked="{Binding Anonymous, Mode=TwoWay}" Content="{x:Static assets:Resources.FtpAnonymous}"/>
 
-			<TextBlock Text="{x:Static assets:Resources.FtpPassword}" IsEnabled="{Binding !Anonymous}"/>
-			<TextBox Text="{Binding Password, Mode=TwoWay}" PasswordChar="●" IsEnabled="{Binding !Anonymous}"/>
-		</StackPanel>
+		<TextBlock Grid.Row="4" Grid.Column="0" Margin="0,0,10,10" VerticalAlignment="Center"
+				   IsEnabled="{Binding !Anonymous}" Text="{x:Static assets:Resources.FtpUsername}"/>
+		<TextBox Grid.Row="4" Grid.Column="1" Margin="0,0,0,10"
+				 Text="{Binding Username, Mode=TwoWay}" IsEnabled="{Binding !Anonymous}"/>
 
-		<StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+		<TextBlock Grid.Row="5" Grid.Column="0" Margin="0,0,10,10" VerticalAlignment="Center"
+				   IsEnabled="{Binding !Anonymous}" Text="{x:Static assets:Resources.FtpPassword}"/>
+		<TextBox Grid.Row="5" Grid.Column="1" Margin="0,0,0,10"
+				 Text="{Binding Password, Mode=TwoWay}" PasswordChar="●" IsEnabled="{Binding !Anonymous}"/>
+
+		<StackPanel Grid.Row="6" Grid.Column="0" Grid.ColumnSpan="2" Orientation="Horizontal"
+					HorizontalAlignment="Right" VerticalAlignment="Bottom">
 			<Button Margin="5" Command="{Binding OKCommand}" CommandParameter="{Binding $parent[Window]}" IsDefault="True"
 					Content="{x:Static assets:Resources.FtpConnectButton}"/>
 			<Button Margin="5" Command="{Binding CancelCommand}" CommandParameter="{Binding $parent[Window]}" IsCancel="True"

--- a/src/SmartCommander/Views/FtpConnectWindow.axaml.cs
+++ b/src/SmartCommander/Views/FtpConnectWindow.axaml.cs
@@ -1,0 +1,13 @@
+using Avalonia.Controls;
+
+namespace SmartCommander.Views
+{
+    public partial class FtpConnectWindow : Window
+    {
+        public FtpConnectWindow()
+        {
+            InitializeComponent();
+            Opened += (s, e) => HostTextBox.Focus();
+        }
+    }
+}

--- a/src/SmartCommander/Views/MainWindow.axaml
+++ b/src/SmartCommander/Views/MainWindow.axaml
@@ -75,6 +75,11 @@
 		  <MenuItem Header="{x:Static assets:Resources.MenuOptions}" Command="{Binding OptionsCommand}"></MenuItem>
       </MenuItem>
 
+      <MenuItem Header="{x:Static assets:Resources.MenuFtp}" IsTabStop="False" >
+		  <MenuItem Header="{x:Static assets:Resources.MenuFtpConnect}" Command="{Binding ConnectFtpCommand}"></MenuItem>
+		  <MenuItem Header="{x:Static assets:Resources.MenuFtpDisconnect}" Command="{Binding DisconnectFtpCommand}"></MenuItem>
+      </MenuItem>
+
       <MenuItem Header="{x:Static assets:Resources.MenuHelp}" IsTabStop="False" >
 		  <MenuItem Header="{x:Static assets:Resources.MenuAbout}" Command="{Binding AboutCommand}"></MenuItem>
       </MenuItem>

--- a/src/SmartCommander/Views/MainWindow.axaml.cs
+++ b/src/SmartCommander/Views/MainWindow.axaml.cs
@@ -40,6 +40,9 @@ namespace SmartCommander.Views
             this.WhenActivated(d => d(ViewModel!.ShowAboutDialog.RegisterHandler(
                 interaction => DoShowDialogAsync<AboutViewModel, AboutWindow>(interaction)
             )));
+            this.WhenActivated(d => d(ViewModel!.ShowFtpConnectDialog.RegisterHandler(
+                interaction => DoShowDialogAsync<FtpConnectViewModel, FtpConnectWindow>(interaction)
+            )));
 
             operationsWindow = new OperationsWindow();
 


### PR DESCRIPTION
Adds basic FTP support to the file panes: connect via a new FTP menu with a saved-connections dropdown (anonymous or credentialed, sorted by most recently successfully used), browse and navigate remote directories alongside local ones, and copy/move files and folders in either direction between a local pane and an FTP pane (upload/download), including rename, delete, and create-folder over FTP. Error handling was hardened throughout: failed transfers, connects, listings, and deletes now surface the real server/network reason instead of FluentFTP's generic wrapper message, directory transfers report every failed file rather than just the first, and double-clicking a file over FTP shows a clear "not supported yet" message.

Covered by new unit tests plus an opt-in integration suite exercising real public FTP servers (Rebex read-only, dlptest.com and dlp-test.com read-write) for connect, list, upload, download, rename, and delete. View/Edit over FTP is intentionally out of scope for this PR (tracked separately).

Closes https://github.com/anovik/SmartCommander/issues/20