### PR TITLE
Add Rename and New Folder to file context menu.

### DIFF
--- a/src/SmartCommander/Assets/Resources.Designer.cs
+++ b/src/SmartCommander/Assets/Resources.Designer.cs
@@ -1121,5 +1121,14 @@ namespace SmartCommander.Assets {
                 return ResourceManager.GetString("CantOpenFtpFile", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Rename.
+        /// </summary>
+        public static string Rename {
+            get {
+                return ResourceManager.GetString("Rename", resourceCulture);
+            }
+        }
     }
 }

--- a/src/SmartCommander/Assets/Resources.fr-FR.resx
+++ b/src/SmartCommander/Assets/Resources.fr-FR.resx
@@ -471,4 +471,7 @@
   <data name="CantOpenFtpFile" xml:space="preserve">
     <value>L'ouverture des fichiers FTP n'est pas encore prise en charge</value>
   </data>
+  <data name="Rename" xml:space="preserve">
+    <value>Renommer</value>
+  </data>
 </root>

--- a/src/SmartCommander/Assets/Resources.resx
+++ b/src/SmartCommander/Assets/Resources.resx
@@ -471,4 +471,7 @@
   <data name="CantOpenFtpFile" xml:space="preserve">
     <value>Opening FTP files isn't supported yet</value>
   </data>
+  <data name="Rename" xml:space="preserve">
+    <value>Rename</value>
+  </data>
 </root>

--- a/src/SmartCommander/Assets/Resources.ru-RU.resx
+++ b/src/SmartCommander/Assets/Resources.ru-RU.resx
@@ -471,4 +471,7 @@
   <data name="CantOpenFtpFile" xml:space="preserve">
     <value>Открытие файлов по FTP пока не поддерживается</value>
   </data>
+  <data name="Rename" xml:space="preserve">
+    <value>Переименовать</value>
+  </data>
 </root>

--- a/src/SmartCommander/Assets/Resources.sr-Cyrl-RS.resx
+++ b/src/SmartCommander/Assets/Resources.sr-Cyrl-RS.resx
@@ -471,4 +471,7 @@
   <data name="CantOpenFtpFile" xml:space="preserve">
     <value>Отварање FTP фајлова још није подржано</value>
   </data>
+  <data name="Rename" xml:space="preserve">
+    <value>Преименуј</value>
+  </data>
 </root>

--- a/src/SmartCommander/Assets/Resources.sr-Latn-ME.resx
+++ b/src/SmartCommander/Assets/Resources.sr-Latn-ME.resx
@@ -471,4 +471,7 @@
   <data name="CantOpenFtpFile" xml:space="preserve">
     <value>Otvaranje FTP fajlova još nije podržano</value>
   </data>
+  <data name="Rename" xml:space="preserve">
+    <value>Preimenuj</value>
+  </data>
 </root>

--- a/src/SmartCommander/ViewModels/FilesPaneViewModel.cs
+++ b/src/SmartCommander/ViewModels/FilesPaneViewModel.cs
@@ -80,13 +80,23 @@ namespace SmartCommander.ViewModels
         private MainWindowViewModel.FtpTransferMenuMode TransferMenuMode =>
             MainWindowViewModel.DetermineFtpTransferMenuMode(IsFtp, RemotePath.IsFtp(_mainVM.OtherPane(this).CurrentDirectory));
 
-        public bool ShowLocalCopyCut => TransferMenuMode == MainWindowViewModel.FtpTransferMenuMode.LocalClipboard;
-        public bool ShowDownload => TransferMenuMode == MainWindowViewModel.FtpTransferMenuMode.Download;
-        public bool ShowUpload => TransferMenuMode == MainWindowViewModel.FtpTransferMenuMode.Upload;
+        // ".." isn't a real file/folder - it gets the background-style menu (Paste/New
+        // Folder/MoreOptions), not the item-specific menu below.
+        public bool IsRealItemSelected => CurrentItem != null && CurrentItem.FullName != "..";
+        public bool IsParentEntrySelected => CurrentItem != null && CurrentItem.FullName == "..";
 
-        public bool ShowZip => !IsFtp && !IsUnzip;
-        public bool ShowUnzip => !IsFtp && IsUnzip;
+        public bool ShowLocalCopyCut => IsRealItemSelected && TransferMenuMode == MainWindowViewModel.FtpTransferMenuMode.LocalClipboard;
+        public bool ShowDownload => IsRealItemSelected && TransferMenuMode == MainWindowViewModel.FtpTransferMenuMode.Download;
+        public bool ShowUpload => IsRealItemSelected && TransferMenuMode == MainWindowViewModel.FtpTransferMenuMode.Upload;
+        public bool ShowFtpMove => IsRealItemSelected && !ShowLocalCopyCut;
+
+        public bool ShowZip => IsRealItemSelected && !IsFtp && !IsUnzip;
+        public bool ShowUnzip => IsRealItemSelected && !IsFtp && IsUnzip;
         public bool CanShowMoreOptions => !IsFtp && IsWindows;
+        public bool CanShowItemMoreOptions => IsRealItemSelected && CanShowMoreOptions;
+        // Covers both ".." and no selection at all (e.g. an empty directory) - either way
+        // there's no real item to act on, so this falls back to directory-level options.
+        public bool CanShowBackgroundMoreOptions => !IsRealItemSelected && CanShowMoreOptions;
 
         private bool _canPaste;
         public bool CanPaste
@@ -161,6 +171,8 @@ namespace SmartCommander.ViewModels
             TransferCommand = ReactiveCommand.CreateFromTask(() => _mainVM.Copy());
             FtpMoveCommand = ReactiveCommand.CreateFromTask(() => _mainVM.Move());
             DeleteCommand = ReactiveCommand.CreateFromTask(Delete);
+            RenameCommand = ReactiveCommand.Create(Rename);
+            NewFolderCommand = ReactiveCommand.Create(NewFolder);
             PasteCommand = ReactiveCommand.CreateFromTask(Paste, this.WhenAnyValue(x => x.CanPaste));
             ShowMoreOptionsCommand = ReactiveCommand.CreateFromTask(ShowMoreOptions);
             ShowViewerDialog = new Interaction<ViewerViewModel, ViewerViewModel?>();
@@ -184,6 +196,8 @@ namespace SmartCommander.ViewModels
         public ReactiveCommand<Unit, Unit>? TransferCommand { get; }
         public ReactiveCommand<Unit, Unit>? FtpMoveCommand { get; }
         public ReactiveCommand<Unit, Unit>? DeleteCommand { get; }
+        public ReactiveCommand<Unit, Unit>? RenameCommand { get; }
+        public ReactiveCommand<Unit, Unit>? NewFolderCommand { get; }
         public ReactiveCommand<Unit, Unit>? PasteCommand { get; }
         public ReactiveCommand<Unit, Unit>? ShowMoreOptionsCommand { get; }
 
@@ -545,6 +559,16 @@ namespace SmartCommander.ViewModels
 
         public async Task ShowMoreOptions()
         {
+            // ".." isn't a real path - treat it like no selection (background options for the directory).
+            if (IsParentEntrySelected)
+            {
+                if (ShowWindowsContextMenuInteraction != null)
+                {
+                    await ShowWindowsContextMenuInteraction.Handle(new string[] { CurrentDirectory });
+                }
+                return;
+            }
+
             if (CurrentItems == null || CurrentItems.Count == 0)
             {
                 if (CurrentItem != null)
@@ -588,6 +612,52 @@ namespace SmartCommander.ViewModels
                 return;
             }
             await _fs.CreateDirectoryAsync(newFolder);
+        }
+
+        public void NewFolder()
+        {
+            // Shared with MainWindowViewModel.CreateNewFolder (F7) so the two entry points
+            // can't stack two dialogs.
+            if (!_mainVM.TryBeginNewFolderDialog())
+            {
+                return;
+            }
+            MessageBoxInput_Show(NewFolderAnswer, Resources.CreateNewFolder);
+        }
+
+        private async void NewFolderAnswer(string result)
+        {
+            try
+            {
+                if (!string.IsNullOrEmpty(result))
+                {
+                    await CreateNewFolder(result);
+                    Update();
+                    _mainVM.OtherPane(this).Update();
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "NewFolder failed");
+                MessageBox_Show(null, Resources.CantCreateFolder, Resources.Alert);
+            }
+            finally
+            {
+                _mainVM.EndNewFolderDialog();
+            }
+        }
+
+        // The View starts the same inline DataGrid cell edit BeginningEdit/Name already drive -
+        // this is just another trigger for it, not a separate rename path.
+        public event EventHandler? RenameRequested;
+
+        public void Rename()
+        {
+            if (!IsRealItemSelected)
+            {
+                return;
+            }
+            RenameRequested?.Invoke(this, EventArgs.Empty);
         }
 
         public async Task ProcessCurrentItem(bool goToParent = false)

--- a/src/SmartCommander/ViewModels/MainWindowViewModel.cs
+++ b/src/SmartCommander/ViewModels/MainWindowViewModel.cs
@@ -132,7 +132,9 @@ namespace SmartCommander.ViewModels
 
         volatile bool _F3Busy;
         volatile bool _F4Busy;
-        volatile bool _F7Busy;
+        // Shared by both F7 and the pane's right-click "New Folder" so the two entry points
+        // can't stack two dialogs at once.
+        volatile bool _newFolderDialogBusy;
 
         public string CommandText
         {
@@ -879,13 +881,29 @@ namespace SmartCommander.ViewModels
             }
         }
 
+        // Shared with FilesPaneViewModel.NewFolder so pressing F7 and right-clicking "New
+        // Folder" in quick succession can't stack two dialogs.
+        internal bool TryBeginNewFolderDialog()
+        {
+            if (_newFolderDialogBusy)
+            {
+                return false;
+            }
+            _newFolderDialogBusy = true;
+            return true;
+        }
+
+        internal void EndNewFolderDialog()
+        {
+            _newFolderDialogBusy = false;
+        }
+
         public void CreateNewFolder()
         {
-            if (_F7Busy)
+            if (!TryBeginNewFolderDialog())
             {
                 return;
             }
-            _F7Busy = true;
             MessageBoxInput_Show(CreateNewFolderAnswer, Resources.CreateNewFolder);
         }
 
@@ -907,7 +925,7 @@ namespace SmartCommander.ViewModels
             }
             finally
             {
-                _F7Busy = false;
+                EndNewFolderDialog();
             }
         }
 

--- a/src/SmartCommander/Views/FilesPane.axaml
+++ b/src/SmartCommander/Views/FilesPane.axaml
@@ -38,6 +38,8 @@
 			<MenuFlyout>
 				<MenuItem Header="{x:Static assets:Resources.Paste}"
 						  Command="{Binding PasteCommand}" />
+				<MenuItem Header="{x:Static assets:Resources.CreateNewFolder}"
+						  Command="{Binding NewFolderCommand}" />
 				<MenuItem Header="{x:Static assets:Resources.MoreOptions}"
 						  IsVisible="{Binding CanShowMoreOptions}"
 						  Command="{Binding ShowMoreOptionsCommand}" />
@@ -87,8 +89,22 @@
 
 			<DataGrid.ContextFlyout>
 				<MenuFlyout>
-					<MenuItem Header="{x:Static assets:Resources.View}" Command="{Binding ViewCommand}" />
-					<MenuItem Header="{x:Static assets:Resources.Edit}" Command="{Binding EditCommand}" />
+					<!-- No real item selected (".." or an empty directory) gets the background-style menu, not the item menu. -->
+					<MenuItem Header="{x:Static assets:Resources.Paste}"
+                              IsVisible="{Binding !IsRealItemSelected}"
+                              Command="{Binding PasteCommand}" />
+					<MenuItem Header="{x:Static assets:Resources.CreateNewFolder}"
+                              IsVisible="{Binding !IsRealItemSelected}"
+                              Command="{Binding NewFolderCommand}" />
+					<MenuItem Header="{x:Static assets:Resources.MoreOptions}"
+                              IsVisible="{Binding CanShowBackgroundMoreOptions}"
+                              Command="{Binding ShowMoreOptionsCommand}" />
+					<MenuItem Header="{x:Static assets:Resources.View}"
+                              IsVisible="{Binding IsRealItemSelected}"
+                              Command="{Binding ViewCommand}" />
+					<MenuItem Header="{x:Static assets:Resources.Edit}"
+                              IsVisible="{Binding IsRealItemSelected}"
+                              Command="{Binding EditCommand}" />
 					<MenuItem Header="{x:Static assets:Resources.Copy}"
                               IsVisible="{Binding ShowLocalCopyCut}"
                               Command="{Binding CopyCommand}" />
@@ -102,9 +118,14 @@
                               IsVisible="{Binding ShowUpload}"
                               Command="{Binding TransferCommand}" />
 					<MenuItem Header="{x:Static assets:Resources.Move}"
-                              IsVisible="{Binding !ShowLocalCopyCut}"
+                              IsVisible="{Binding ShowFtpMove}"
                               Command="{Binding FtpMoveCommand}" />
-					<MenuItem Header="{x:Static assets:Resources.Delete}" Command="{Binding DeleteCommand}" />
+					<MenuItem Header="{x:Static assets:Resources.Rename}"
+                              IsVisible="{Binding IsRealItemSelected}"
+                              Command="{Binding RenameCommand}" />
+					<MenuItem Header="{x:Static assets:Resources.Delete}"
+                              IsVisible="{Binding IsRealItemSelected}"
+                              Command="{Binding DeleteCommand}" />
 					<MenuItem Header="{x:Static assets:Resources.Zip}"
                               IsVisible="{Binding ShowZip, Mode=TwoWay}"
                               Command="{Binding ZipCommand}" />
@@ -112,7 +133,7 @@
                               IsVisible="{Binding ShowUnzip, Mode=TwoWay}"
                               Command="{Binding UnzipCommand}" />
 					<MenuItem Header="{x:Static assets:Resources.MoreOptions}"
-                              IsVisible="{Binding CanShowMoreOptions}"
+                              IsVisible="{Binding CanShowItemMoreOptions}"
                               Command="{Binding ShowMoreOptionsCommand}" />
 				</MenuFlyout>
 			</DataGrid.ContextFlyout>

--- a/src/SmartCommander/Views/FilesPane.axaml.cs
+++ b/src/SmartCommander/Views/FilesPane.axaml.cs
@@ -122,12 +122,26 @@ namespace SmartCommander.Views
                     PaneDataGrid.ScrollIntoView(item, (DataGridColumn)column);
                     PaneDataGrid.Focus();
                 };
+                viewModel.RenameRequested += (s, args) => BeginRenameEdit();
             }
         }
 
         public void FocusGrid()
         {
             paneDataGrid?.Focus();
+        }
+
+        // Column 1 is always Name (matches the DisplayIndex check in
+        // FilesPaneViewModel.BeginningEdit) - point the grid at it and start editing.
+        private void BeginRenameEdit()
+        {
+            if (paneDataGrid == null)
+            {
+                return;
+            }
+            paneDataGrid.Focus();
+            paneDataGrid.CurrentColumn = paneDataGrid.Columns[1];
+            paneDataGrid.BeginEdit();
         }
 
 

--- a/src/SmartCommander/Views/MvvmMessageBoxEventArgs.cs
+++ b/src/SmartCommander/Views/MvvmMessageBoxEventArgs.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia.Controls;
+﻿using Avalonia;
+using Avalonia.Controls;
 using Avalonia.LogicalTree;
 using Avalonia.Threading;
 using MsBox.Avalonia.Dto;
@@ -118,7 +119,7 @@ namespace SmartCommander.Views
                     var messageBoxWindow = MsBox.Avalonia.MessageBoxManager
                         .GetMessageBoxCustom(new MessageBoxCustomParams()
                         {
-                            ContentHeader = messageBoxText,
+                            ContentTitle = messageBoxText,
                             ContentMessage = "",
                             MinWidth = 300,
                             InputParams = new InputParams() { },
@@ -159,6 +160,16 @@ namespace SmartCommander.Views
 
             var inputTextBox = content.GetLogicalDescendants().OfType<TextBox>().FirstOrDefault(t => !t.IsReadOnly);
             inputTextBox?.Focus();
+
+            // The library's input row is a fixed 15px Grid row (ignores child margin), so push
+            // the Auto-sized buttons row down instead to open up the gap.
+            var buttonsPresenter = content.GetLogicalDescendants()
+                .OfType<ItemsControl>()
+                .FirstOrDefault(c => c.Name == "ButtonItemsPresenter");
+            if (buttonsPresenter != null)
+            {
+                buttonsPresenter.Margin = new Thickness(0, 20, 0, 0);
+            }
         }
     }
 }


### PR DESCRIPTION
Rename triggers the existing in-place cell edit. New Folder reuses F7's logic. 

Both are hidden for ".." and shown as background-style actions (Paste/New Folder/More Options) when no real item is selected, matching empty-directory right-clicks. 

Also moves the New Folder dialog's title into the window title bar and fixes itsinput/button spacing.