### PR TITLE
Add password-protected zip with compression options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ dotnet build src --configuration Release
 
 - FTP support (connect, browse, upload, download files and folders)
 
-- Creating and unzipping of ZIP archives
+- Creating and unzipping of ZIP archives (encryption/decryption and compression choice options)
   
 - Unicode support
   

--- a/src/SmartCommander.Tests/ArchiveServiceTests.cs
+++ b/src/SmartCommander.Tests/ArchiveServiceTests.cs
@@ -1,0 +1,208 @@
+using ICSharpCode.SharpZipLib.Zip;
+using SmartCommander.Services;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SmartCommander.Tests
+{
+    public class ArchiveServiceTests : IDisposable
+    {
+        private readonly string _root;
+        private readonly ArchiveService _svc = new();
+        private static readonly IProgress<int> NoProgress = new Progress<int>();
+
+        public ArchiveServiceTests()
+        {
+            _root = Path.Combine(Path.GetTempPath(), "SCArchiveTests_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_root);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(_root))
+            {
+                Directory.Delete(_root, recursive: true);
+            }
+        }
+
+        // Builds root/src/{a.txt, sub/b.txt} with compressible content, returns the src dir path.
+        private string BuildSampleTree()
+        {
+            var src = Path.Combine(_root, "src");
+            Directory.CreateDirectory(Path.Combine(src, "sub"));
+            File.WriteAllText(Path.Combine(src, "a.txt"), Repeat("alpha ", 2000));
+            File.WriteAllText(Path.Combine(src, "sub", "b.txt"), Repeat("bravo ", 2000));
+            return src;
+        }
+
+        private static string Repeat(string s, int count) => string.Concat(Enumerable.Repeat(s, count));
+
+        private static long TotalSize(string dir) =>
+            Directory.GetFiles(dir, "*", SearchOption.AllDirectories).Sum(f => new FileInfo(f).Length);
+
+        private List<(string FullName, bool IsFolder)> FolderItem(string dir) => new() { (dir, true) };
+
+        [Fact]
+        public async Task PlainZip_RoundTrips_FileSetAndContentsAndStructure()
+        {
+            var src = BuildSampleTree();
+            var zipPath = Path.Combine(_root, "plain.zip");
+            var dest = Path.Combine(_root, "out");
+
+            await _svc.CreateZipAsync(FolderItem(src), zipPath, ZipCompressionLevel.Normal, null,
+                TotalSize(src), NoProgress, CancellationToken.None);
+            await _svc.ExtractZipAsync(zipPath, dest, null, NoProgress, CancellationToken.None);
+
+            Assert.False(_svc.IsEncrypted(zipPath));
+            Assert.True(File.Exists(Path.Combine(dest, "src", "a.txt")));
+            Assert.True(File.Exists(Path.Combine(dest, "src", "sub", "b.txt")));
+            Assert.Equal(File.ReadAllText(Path.Combine(src, "a.txt")),
+                File.ReadAllText(Path.Combine(dest, "src", "a.txt")));
+            Assert.Equal(File.ReadAllText(Path.Combine(src, "sub", "b.txt")),
+                File.ReadAllText(Path.Combine(dest, "src", "sub", "b.txt")));
+        }
+
+        [Fact]
+        public async Task EncryptedZip_RoundTrips_AndPasswordChecks()
+        {
+            var src = BuildSampleTree();
+            var zipPath = Path.Combine(_root, "enc.zip");
+            var dest = Path.Combine(_root, "out");
+            const string password = "s3cr3t-pass";
+
+            await _svc.CreateZipAsync(FolderItem(src), zipPath, ZipCompressionLevel.Maximum, password,
+                TotalSize(src), NoProgress, CancellationToken.None);
+
+            Assert.True(_svc.IsEncrypted(zipPath));
+            Assert.True(_svc.VerifyPassword(zipPath, password));
+            Assert.False(_svc.VerifyPassword(zipPath, "wrong-pass"));
+
+            await _svc.ExtractZipAsync(zipPath, dest, password, NoProgress, CancellationToken.None);
+            Assert.Equal(File.ReadAllText(Path.Combine(src, "a.txt")),
+                File.ReadAllText(Path.Combine(dest, "src", "a.txt")));
+            Assert.Equal(File.ReadAllText(Path.Combine(src, "sub", "b.txt")),
+                File.ReadAllText(Path.Combine(dest, "src", "sub", "b.txt")));
+        }
+
+        [Fact]
+        public async Task ExtractZipAsync_WrongPassword_ThrowsInvalidPasswordException()
+        {
+            var src = BuildSampleTree();
+            var zipPath = Path.Combine(_root, "enc.zip");
+            var dest = Path.Combine(_root, "out");
+
+            await _svc.CreateZipAsync(FolderItem(src), zipPath, ZipCompressionLevel.Normal, "right-pass",
+                TotalSize(src), NoProgress, CancellationToken.None);
+
+            await Assert.ThrowsAsync<InvalidPasswordException>(() =>
+                _svc.ExtractZipAsync(zipPath, dest, "bad-pass", NoProgress, CancellationToken.None));
+        }
+
+        [Theory]
+        [InlineData(ZipCompressionLevel.Store)]
+        [InlineData(ZipCompressionLevel.Fastest)]
+        [InlineData(ZipCompressionLevel.Normal)]
+        [InlineData(ZipCompressionLevel.Maximum)]
+        public async Task EachLevel_ProducesValidExtractableArchive(ZipCompressionLevel level)
+        {
+            var src = BuildSampleTree();
+            var zipPath = Path.Combine(_root, $"lvl-{level}.zip");
+            var dest = Path.Combine(_root, $"out-{level}");
+
+            await _svc.CreateZipAsync(FolderItem(src), zipPath, level, null,
+                TotalSize(src), NoProgress, CancellationToken.None);
+            await _svc.ExtractZipAsync(zipPath, dest, null, NoProgress, CancellationToken.None);
+
+            Assert.Equal(File.ReadAllText(Path.Combine(src, "a.txt")),
+                File.ReadAllText(Path.Combine(dest, "src", "a.txt")));
+        }
+
+        [Fact]
+        public async Task StoreOutput_IsNotSmallerThan_MaximumOutput_ForCompressibleInput()
+        {
+            var src = BuildSampleTree();
+            var storeZip = Path.Combine(_root, "store.zip");
+            var maxZip = Path.Combine(_root, "max.zip");
+
+            await _svc.CreateZipAsync(FolderItem(src), storeZip, ZipCompressionLevel.Store, null,
+                TotalSize(src), NoProgress, CancellationToken.None);
+            await _svc.CreateZipAsync(FolderItem(src), maxZip, ZipCompressionLevel.Maximum, null,
+                TotalSize(src), NoProgress, CancellationToken.None);
+
+            Assert.True(new FileInfo(storeZip).Length >= new FileInfo(maxZip).Length);
+        }
+
+        [Fact]
+        public async Task ExtractZipAsync_ZipSlipEntry_IsRejected()
+        {
+            var zipPath = Path.Combine(_root, "evil.zip");
+            using (var stream = File.Create(zipPath))
+            using (var zos = new ZipOutputStream(stream))
+            {
+                zos.SetLevel(0);
+                var bytes = System.Text.Encoding.UTF8.GetBytes("pwned");
+                // Raw name, bypassing ZipEntry.CleanName, to simulate a crafted archive.
+                var entry = new ZipEntry("../evil.txt") { Size = bytes.Length };
+                zos.PutNextEntry(entry);
+                zos.Write(bytes, 0, bytes.Length);
+                zos.CloseEntry();
+                zos.Finish();
+            }
+
+            var dest = Path.Combine(_root, "out");
+            await Assert.ThrowsAsync<IOException>(() =>
+                _svc.ExtractZipAsync(zipPath, dest, null, NoProgress, CancellationToken.None));
+            Assert.False(File.Exists(Path.Combine(_root, "evil.txt")));
+        }
+
+        [Fact]
+        public async Task CreateZipAsync_AlreadyCancelledToken_ThrowsAndLeavesNoArchive()
+        {
+            var src = BuildSampleTree();
+            var zipPath = Path.Combine(_root, "cancelled.zip");
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                _svc.CreateZipAsync(FolderItem(src), zipPath, ZipCompressionLevel.Normal, null,
+                    TotalSize(src), NoProgress, cts.Token));
+
+            Assert.False(File.Exists(zipPath));
+        }
+
+        [Fact]
+        public async Task CreateZipAsync_TargetAlreadyExists_ThrowsAndLeavesItUntouched()
+        {
+            var src = BuildSampleTree();
+            var zipPath = Path.Combine(_root, "taken.zip");
+            File.WriteAllText(zipPath, "not a zip");
+
+            await Assert.ThrowsAsync<IOException>(() =>
+                _svc.CreateZipAsync(FolderItem(src), zipPath, ZipCompressionLevel.Normal, null,
+                    TotalSize(src), NoProgress, CancellationToken.None));
+
+            Assert.Equal("not a zip", File.ReadAllText(zipPath));
+        }
+
+        [Fact]
+        public async Task ExtractZipAsync_AlreadyCancelledToken_Throws()
+        {
+            var src = BuildSampleTree();
+            var zipPath = Path.Combine(_root, "src.zip");
+            await _svc.CreateZipAsync(FolderItem(src), zipPath, ZipCompressionLevel.Normal, null,
+                TotalSize(src), NoProgress, CancellationToken.None);
+
+            var dest = Path.Combine(_root, "out");
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                _svc.ExtractZipAsync(zipPath, dest, null, NoProgress, cts.Token));
+        }
+    }
+}

--- a/src/SmartCommander/Assets/Resources.Designer.cs
+++ b/src/SmartCommander/Assets/Resources.Designer.cs
@@ -1121,5 +1121,122 @@ namespace SmartCommander.Assets {
                 return ResourceManager.GetString("Rename", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Zip with options….
+        /// </summary>
+        public static string ZipWithOptions {
+            get {
+                return ResourceManager.GetString("ZipWithOptions", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Zip with options.
+        /// </summary>
+        public static string ZipOptionsTitle {
+            get {
+                return ResourceManager.GetString("ZipOptionsTitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Password.
+        /// </summary>
+        public static string Password {
+            get {
+                return ResourceManager.GetString("Password", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Confirm password.
+        /// </summary>
+        public static string ConfirmPassword {
+            get {
+                return ResourceManager.GetString("ConfirmPassword", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Passwords do not match.
+        /// </summary>
+        public static string PasswordsDoNotMatch {
+            get {
+                return ResourceManager.GetString("PasswordsDoNotMatch", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Compression level.
+        /// </summary>
+        public static string CompressionLevel {
+            get {
+                return ResourceManager.GetString("CompressionLevel", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Store (no compression).
+        /// </summary>
+        public static string CompressionStore {
+            get {
+                return ResourceManager.GetString("CompressionStore", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Fastest.
+        /// </summary>
+        public static string CompressionFastest {
+            get {
+                return ResourceManager.GetString("CompressionFastest", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Normal.
+        /// </summary>
+        public static string CompressionNormal {
+            get {
+                return ResourceManager.GetString("CompressionNormal", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Maximum.
+        /// </summary>
+        public static string CompressionMaximum {
+            get {
+                return ResourceManager.GetString("CompressionMaximum", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Enter the archive password:.
+        /// </summary>
+        public static string EnterArchivePassword {
+            get {
+                return ResourceManager.GetString("EnterArchivePassword", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Wrong password. Try again..
+        /// </summary>
+        public static string WrongArchivePassword {
+            get {
+                return ResourceManager.GetString("WrongArchivePassword", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Show password.
+        /// </summary>
+        public static string ShowPassword {
+            get {
+                return ResourceManager.GetString("ShowPassword", resourceCulture);
+            }
+        }
     }
 }

--- a/src/SmartCommander/Assets/Resources.fr-FR.resx
+++ b/src/SmartCommander/Assets/Resources.fr-FR.resx
@@ -471,4 +471,43 @@
   <data name="Rename" xml:space="preserve">
     <value>Renommer</value>
   </data>
+  <data name="ZipWithOptions" xml:space="preserve">
+    <value>Compresser avec options…</value>
+  </data>
+  <data name="ZipOptionsTitle" xml:space="preserve">
+    <value>Compresser avec options</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Mot de passe</value>
+  </data>
+  <data name="ConfirmPassword" xml:space="preserve">
+    <value>Confirmer le mot de passe</value>
+  </data>
+  <data name="PasswordsDoNotMatch" xml:space="preserve">
+    <value>Les mots de passe ne correspondent pas</value>
+  </data>
+  <data name="CompressionLevel" xml:space="preserve">
+    <value>Niveau de compression</value>
+  </data>
+  <data name="CompressionStore" xml:space="preserve">
+    <value>Aucune compression</value>
+  </data>
+  <data name="CompressionFastest" xml:space="preserve">
+    <value>Le plus rapide</value>
+  </data>
+  <data name="CompressionNormal" xml:space="preserve">
+    <value>Normal</value>
+  </data>
+  <data name="CompressionMaximum" xml:space="preserve">
+    <value>Maximum</value>
+  </data>
+  <data name="EnterArchivePassword" xml:space="preserve">
+    <value>Saisissez le mot de passe de l'archive :</value>
+  </data>
+  <data name="WrongArchivePassword" xml:space="preserve">
+    <value>Mot de passe incorrect. Réessayez.</value>
+  </data>
+  <data name="ShowPassword" xml:space="preserve">
+    <value>Afficher le mot de passe</value>
+  </data>
 </root>

--- a/src/SmartCommander/Assets/Resources.resx
+++ b/src/SmartCommander/Assets/Resources.resx
@@ -471,4 +471,43 @@
   <data name="Rename" xml:space="preserve">
     <value>Rename</value>
   </data>
+  <data name="ZipWithOptions" xml:space="preserve">
+    <value>Zip with options…</value>
+  </data>
+  <data name="ZipOptionsTitle" xml:space="preserve">
+    <value>Zip with options</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Password</value>
+  </data>
+  <data name="ConfirmPassword" xml:space="preserve">
+    <value>Confirm password</value>
+  </data>
+  <data name="PasswordsDoNotMatch" xml:space="preserve">
+    <value>Passwords do not match</value>
+  </data>
+  <data name="CompressionLevel" xml:space="preserve">
+    <value>Compression level</value>
+  </data>
+  <data name="CompressionStore" xml:space="preserve">
+    <value>Store (no compression)</value>
+  </data>
+  <data name="CompressionFastest" xml:space="preserve">
+    <value>Fastest</value>
+  </data>
+  <data name="CompressionNormal" xml:space="preserve">
+    <value>Normal</value>
+  </data>
+  <data name="CompressionMaximum" xml:space="preserve">
+    <value>Maximum</value>
+  </data>
+  <data name="EnterArchivePassword" xml:space="preserve">
+    <value>Enter the archive password:</value>
+  </data>
+  <data name="WrongArchivePassword" xml:space="preserve">
+    <value>Wrong password. Try again.</value>
+  </data>
+  <data name="ShowPassword" xml:space="preserve">
+    <value>Show password</value>
+  </data>
 </root>

--- a/src/SmartCommander/Assets/Resources.ru-RU.resx
+++ b/src/SmartCommander/Assets/Resources.ru-RU.resx
@@ -471,4 +471,43 @@
   <data name="Rename" xml:space="preserve">
     <value>Переименовать</value>
   </data>
+  <data name="ZipWithOptions" xml:space="preserve">
+    <value>Архивировать с параметрами…</value>
+  </data>
+  <data name="ZipOptionsTitle" xml:space="preserve">
+    <value>Архивировать с параметрами</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Пароль</value>
+  </data>
+  <data name="ConfirmPassword" xml:space="preserve">
+    <value>Подтвердите пароль</value>
+  </data>
+  <data name="PasswordsDoNotMatch" xml:space="preserve">
+    <value>Пароли не совпадают</value>
+  </data>
+  <data name="CompressionLevel" xml:space="preserve">
+    <value>Уровень сжатия</value>
+  </data>
+  <data name="CompressionStore" xml:space="preserve">
+    <value>Без сжатия</value>
+  </data>
+  <data name="CompressionFastest" xml:space="preserve">
+    <value>Быстрое</value>
+  </data>
+  <data name="CompressionNormal" xml:space="preserve">
+    <value>Обычное</value>
+  </data>
+  <data name="CompressionMaximum" xml:space="preserve">
+    <value>Максимальное</value>
+  </data>
+  <data name="EnterArchivePassword" xml:space="preserve">
+    <value>Введите пароль архива:</value>
+  </data>
+  <data name="WrongArchivePassword" xml:space="preserve">
+    <value>Неверный пароль. Попробуйте снова.</value>
+  </data>
+  <data name="ShowPassword" xml:space="preserve">
+    <value>Показать пароль</value>
+  </data>
 </root>

--- a/src/SmartCommander/Assets/Resources.sr-Cyrl-RS.resx
+++ b/src/SmartCommander/Assets/Resources.sr-Cyrl-RS.resx
@@ -471,4 +471,43 @@
   <data name="Rename" xml:space="preserve">
     <value>Преименуј</value>
   </data>
+  <data name="ZipWithOptions" xml:space="preserve">
+    <value>Зип са опцијама…</value>
+  </data>
+  <data name="ZipOptionsTitle" xml:space="preserve">
+    <value>Зип са опцијама</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Лозинка</value>
+  </data>
+  <data name="ConfirmPassword" xml:space="preserve">
+    <value>Потврдите лозинку</value>
+  </data>
+  <data name="PasswordsDoNotMatch" xml:space="preserve">
+    <value>Лозинке се не подударају</value>
+  </data>
+  <data name="CompressionLevel" xml:space="preserve">
+    <value>Ниво компресије</value>
+  </data>
+  <data name="CompressionStore" xml:space="preserve">
+    <value>Без компресије</value>
+  </data>
+  <data name="CompressionFastest" xml:space="preserve">
+    <value>Најбрже</value>
+  </data>
+  <data name="CompressionNormal" xml:space="preserve">
+    <value>Нормално</value>
+  </data>
+  <data name="CompressionMaximum" xml:space="preserve">
+    <value>Максимално</value>
+  </data>
+  <data name="EnterArchivePassword" xml:space="preserve">
+    <value>Унесите лозинку архиве:</value>
+  </data>
+  <data name="WrongArchivePassword" xml:space="preserve">
+    <value>Погрешна лозинка. Покушајте поново.</value>
+  </data>
+  <data name="ShowPassword" xml:space="preserve">
+    <value>Прикажи лозинку</value>
+  </data>
 </root>

--- a/src/SmartCommander/Assets/Resources.sr-Latn-ME.resx
+++ b/src/SmartCommander/Assets/Resources.sr-Latn-ME.resx
@@ -471,4 +471,43 @@
   <data name="Rename" xml:space="preserve">
     <value>Preimenuj</value>
   </data>
+  <data name="ZipWithOptions" xml:space="preserve">
+    <value>Zip sa opcijama…</value>
+  </data>
+  <data name="ZipOptionsTitle" xml:space="preserve">
+    <value>Zip sa opcijama</value>
+  </data>
+  <data name="Password" xml:space="preserve">
+    <value>Lozinka</value>
+  </data>
+  <data name="ConfirmPassword" xml:space="preserve">
+    <value>Potvrdite lozinku</value>
+  </data>
+  <data name="PasswordsDoNotMatch" xml:space="preserve">
+    <value>Lozinke se ne podudaraju</value>
+  </data>
+  <data name="CompressionLevel" xml:space="preserve">
+    <value>Nivo kompresije</value>
+  </data>
+  <data name="CompressionStore" xml:space="preserve">
+    <value>Bez kompresije</value>
+  </data>
+  <data name="CompressionFastest" xml:space="preserve">
+    <value>Najbrže</value>
+  </data>
+  <data name="CompressionNormal" xml:space="preserve">
+    <value>Normalno</value>
+  </data>
+  <data name="CompressionMaximum" xml:space="preserve">
+    <value>Maksimalno</value>
+  </data>
+  <data name="EnterArchivePassword" xml:space="preserve">
+    <value>Unesite lozinku arhive:</value>
+  </data>
+  <data name="WrongArchivePassword" xml:space="preserve">
+    <value>Pogrešna lozinka. Pokušajte ponovo.</value>
+  </data>
+  <data name="ShowPassword" xml:space="preserve">
+    <value>Prikaži lozinku</value>
+  </data>
 </root>

--- a/src/SmartCommander/Services/ArchiveService.cs
+++ b/src/SmartCommander/Services/ArchiveService.cs
@@ -1,0 +1,260 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using ICSharpCode.SharpZipLib.Zip;
+
+namespace SmartCommander.Services
+{
+    // Deflate levels behind the 4 UI presets (Store / Fastest / Normal / Maximum).
+    public enum ZipCompressionLevel
+    {
+        Store = 0,
+        Fastest = 1,
+        Normal = 6,
+        Maximum = 9
+    }
+
+    // Thrown by ExtractZipAsync when the archive is encrypted and the supplied
+    // password is wrong (or missing). The pre-launch VerifyPassword loop normally
+    // catches the wrong-password case before extraction starts; this covers the
+    // surprise case (e.g. a mixed-key archive).
+    public class InvalidPasswordException : Exception
+    {
+        public InvalidPasswordException(string message, Exception? inner = null)
+            : base(message, inner)
+        {
+        }
+    }
+
+    // Zip create/extract, both plain and AES-256 encrypted, through a single
+    // SharpZipLib code path (plain = Password left unset). Not part of
+    // IFileSystemService: archive I/O is the documented routing exception.
+    // Instance methods; throws on failure (no message boxes - callers catch and
+    // surface). Directly unit-testable, like LocalFileSystemProviderTests.
+    public class ArchiveService
+    {
+        private const int BufferSize = 81920;
+
+        // BFS over the selection (same walk as the old ZipCore). password null/empty => no encryption.
+        // progress is reported 0..100 against totalSize (sum of the source file lengths).
+        public Task CreateZipAsync(IReadOnlyList<(string FullName, bool IsFolder)> items, string zipPath,
+            ZipCompressionLevel level, string? password, long totalSize,
+            IProgress<int> progress, CancellationToken ct)
+        {
+            return Task.Run(() => CreateZip(items, zipPath, level, password, totalSize, progress, ct), ct);
+        }
+
+        // Entry-by-entry extract, keeps the zip-slip guard. Throws InvalidPasswordException on bad password.
+        // progress is reported 0..100 by entry count.
+        public Task ExtractZipAsync(string zipPath, string destDir, string? password,
+            IProgress<int> progress, CancellationToken ct)
+        {
+            return Task.Run(() => ExtractZip(zipPath, destDir, password, progress, ct), ct);
+        }
+
+        // Quick central-directory scan: true if any file entry is encrypted.
+        public bool IsEncrypted(string zipPath)
+        {
+            using var zf = new ZipFile(zipPath);
+            return zf.Cast<ZipEntry>().Any(e => e.IsFile && e.IsCrypted);
+        }
+
+        // Open the first encrypted file entry and read one byte (AES authentication
+        // happens on read init). Returns false on ZipException, true on success.
+        // Used by the pre-launch retry loop.
+        public bool VerifyPassword(string zipPath, string password)
+        {
+            try
+            {
+                using var zf = new ZipFile(zipPath) { Password = password };
+                var entry = zf.Cast<ZipEntry>().FirstOrDefault(e => e.IsFile && e.IsCrypted);
+                if (entry == null)
+                {
+                    return true;
+                }
+
+                using var stream = zf.GetInputStream(entry);
+                stream.ReadByte();
+                return true;
+            }
+            catch (ZipException)
+            {
+                return false;
+            }
+        }
+
+        private void CreateZip(IReadOnlyList<(string FullName, bool IsFolder)> items, string zipPath,
+            ZipCompressionLevel level, string? password, long totalSize,
+            IProgress<int> progress, CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+            if (items.Count < 1)
+            {
+                return;
+            }
+
+            bool encrypted = !string.IsNullOrEmpty(password);
+
+            // CreateNew, not a truncating open: if anything raced us onto this path since the
+            // caller's File.Exists check, fail here instead of clobbering it. Opened before the
+            // try/catch so the cleanup only ever removes a file this call actually created.
+            var stream = new FileStream(zipPath, FileMode.CreateNew, FileAccess.Write, FileShare.Read);
+            try
+            {
+                progress.Report(0);
+                long processedSize = 0;
+
+                // (entryPrefix, sourcePath) work queue - mirrors the old ZipCore BFS.
+                var queue = new Queue<(string Prefix, string Path)>();
+                foreach (var item in items)
+                {
+                    queue.Enqueue(("", item.FullName));
+                }
+
+                using (stream)
+                using (var zip = new ZipOutputStream(stream))
+                {
+                    zip.SetLevel((int)level);
+                    if (encrypted)
+                    {
+                        zip.Password = password;
+                    }
+
+                    var buffer = new byte[BufferSize];
+                    while (queue.Count > 0)
+                    {
+                        ct.ThrowIfCancellationRequested();
+                        var (prefix, path) = queue.Dequeue();
+
+                        if (Directory.Exists(path))
+                        {
+                            var childPrefix = CombineEntry(prefix, new DirectoryInfo(path).Name);
+                            foreach (var folder in Directory.GetDirectories(path))
+                            {
+                                queue.Enqueue((childPrefix, folder));
+                            }
+                            foreach (var file in Directory.GetFiles(path))
+                            {
+                                queue.Enqueue((childPrefix, file));
+                            }
+                        }
+                        else if (File.Exists(path))
+                        {
+                            var info = new FileInfo(path);
+                            var entry = new ZipEntry(ZipEntry.CleanName(CombineEntry(prefix, info.Name)))
+                            {
+                                DateTime = info.LastWriteTime,
+                                Size = info.Length,
+                                AESKeySize = encrypted ? 256 : 0
+                            };
+                            zip.PutNextEntry(entry);
+
+                            using (var source = File.OpenRead(path))
+                            {
+                                int read;
+                                while ((read = source.Read(buffer, 0, buffer.Length)) > 0)
+                                {
+                                    ct.ThrowIfCancellationRequested();
+                                    zip.Write(buffer, 0, read);
+                                    processedSize += read;
+                                    progress.Report(totalSize <= 0 ? 0 : (int)(processedSize * 100 / totalSize));
+                                }
+                            }
+
+                            zip.CloseEntry();
+                        }
+                    }
+
+                    zip.Finish();
+                }
+
+                progress.Report(100);
+            }
+            catch
+            {
+                // A partial zip (cancelled or failed mid-write) is unusable and would
+                // block a retry via the caller's "archive exists" pre-check. Remove it.
+                TryDelete(zipPath);
+                throw;
+            }
+        }
+
+        private void ExtractZip(string zipPath, string destDir, string? password,
+            IProgress<int> progress, CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            progress.Report(0);
+            Directory.CreateDirectory(destDir);
+            string destDirFull = Path.GetFullPath(destDir + Path.DirectorySeparatorChar);
+
+            using var zip = new ZipFile(zipPath) { Password = string.IsNullOrEmpty(password) ? null : password };
+            var entries = zip.Cast<ZipEntry>().ToList();
+            int total = entries.Count;
+            int done = 0;
+            var buffer = new byte[BufferSize];
+
+            foreach (var entry in entries)
+            {
+                ct.ThrowIfCancellationRequested();
+
+                string destPath = Path.GetFullPath(Path.Combine(destDir, entry.Name));
+                if (!destPath.StartsWith(destDirFull, StringComparison.Ordinal))
+                {
+                    throw new IOException($"Zip entry is outside the target directory: {entry.Name}");
+                }
+
+                if (entry.IsDirectory)
+                {
+                    Directory.CreateDirectory(destPath);
+                }
+                else if (entry.IsFile)
+                {
+                    Directory.CreateDirectory(Path.GetDirectoryName(destPath)!);
+                    try
+                    {
+                        using var input = zip.GetInputStream(entry);
+                        using var output = File.Create(destPath);
+                        int read;
+                        while ((read = input.Read(buffer, 0, buffer.Length)) > 0)
+                        {
+                            ct.ThrowIfCancellationRequested();
+                            output.Write(buffer, 0, read);
+                        }
+                    }
+                    catch (ZipException ex) when (ex.Message.Contains("password", StringComparison.OrdinalIgnoreCase))
+                    {
+                        throw new InvalidPasswordException(ex.Message, ex);
+                    }
+                }
+
+                done++;
+                progress.Report(total == 0 ? 100 : done * 100 / total);
+            }
+        }
+
+        // Zip entry paths always use '/'. Path.Combine would inject '\' on Windows.
+        private static string CombineEntry(string prefix, string name)
+        {
+            return string.IsNullOrEmpty(prefix) ? name : prefix + "/" + name;
+        }
+
+        private static void TryDelete(string path)
+        {
+            try
+            {
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+            catch
+            {
+                // best effort
+            }
+        }
+    }
+}

--- a/src/SmartCommander/SmartCommander.csproj
+++ b/src/SmartCommander/SmartCommander.csproj
@@ -51,6 +51,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="ReactiveUI.Avalonia" Version="12.0.3" />
     <PackageReference Include="Serilog" Version="4.3.0" />
+    <PackageReference Include="SharpZipLib" Version="1.4.2" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Xaml.Behaviors.Avalonia" Version="12.0.0.1" />

--- a/src/SmartCommander/ViewModels/FilesPaneViewModel.cs
+++ b/src/SmartCommander/ViewModels/FilesPaneViewModel.cs
@@ -165,6 +165,7 @@ namespace SmartCommander.ViewModels
             ViewCommand = ReactiveCommand.Create(View);
             EditCommand = ReactiveCommand.Create(Edit);
             ZipCommand = ReactiveCommand.CreateFromTask(Zip);
+            ZipWithOptionsCommand = ReactiveCommand.CreateFromTask(ZipWithOptions);
             UnzipCommand = ReactiveCommand.CreateFromTask(Unzip);
             CopyCommand = ReactiveCommand.CreateFromTask(Copy);
             CutCommand = ReactiveCommand.CreateFromTask(Cut);
@@ -190,6 +191,7 @@ namespace SmartCommander.ViewModels
         public ReactiveCommand<Unit, Unit>? ViewCommand { get; }
         public ReactiveCommand<Unit, Unit>? EditCommand { get; }
         public ReactiveCommand<Unit, Unit>? ZipCommand { get; }
+        public ReactiveCommand<Unit, Unit>? ZipWithOptionsCommand { get; }
         public ReactiveCommand<Unit, Unit>? UnzipCommand { get; }
         public ReactiveCommand<Unit, Unit>? CopyCommand { get; }
         public ReactiveCommand<Unit, Unit>? CutCommand { get; }
@@ -472,6 +474,11 @@ namespace SmartCommander.ViewModels
         public Task Zip()
         {
             return _mainVM.Zip();
+        }
+
+        public Task ZipWithOptions()
+        {
+            return _mainVM.ZipWithOptions();
         }
 
         public Task Unzip()

--- a/src/SmartCommander/ViewModels/MainWindowViewModel.cs
+++ b/src/SmartCommander/ViewModels/MainWindowViewModel.cs
@@ -12,7 +12,6 @@ using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Globalization;
 using System.IO;
-using System.IO.Compression;
 using System.Linq;
 using System.Reactive;
 using System.Reactive.Linq;
@@ -25,6 +24,7 @@ namespace SmartCommander.ViewModels
     public class MainWindowViewModel : ViewModelBase
     {
         private readonly IFileSystemService _fs;
+        private readonly ArchiveService _archives = new();
 
         public MainWindowViewModel(IFileSystemService fs)
         {
@@ -35,6 +35,8 @@ namespace SmartCommander.ViewModels
             ShowSearchDialog = new Interaction<FileSearchViewModel, FileSearchViewModel?>();
             ShowAboutDialog = new Interaction<AboutViewModel, AboutViewModel?>();
             ShowFtpConnectDialog = new Interaction<FtpConnectViewModel, FtpConnectViewModel?>();
+            ShowZipOptionsDialog = new Interaction<ZipOptionsViewModel, ZipOptionsViewModel?>();
+            ShowPasswordPromptDialog = new Interaction<PasswordPromptViewModel, PasswordPromptViewModel?>();
 
             ExitCommand = ReactiveCommand.Create(Exit);
             SortNameCommand = ReactiveCommand.Create(SortName);
@@ -152,6 +154,8 @@ namespace SmartCommander.ViewModels
         public Interaction<FileSearchViewModel, FileSearchViewModel?> ShowSearchDialog { get; }
         public Interaction<AboutViewModel, AboutViewModel?> ShowAboutDialog { get; }
         public Interaction<FtpConnectViewModel, FtpConnectViewModel?> ShowFtpConnectDialog { get; }
+        public Interaction<ZipOptionsViewModel, ZipOptionsViewModel?> ShowZipOptionsDialog { get; }
+        public Interaction<PasswordPromptViewModel, PasswordPromptViewModel?> ShowPasswordPromptDialog { get; }
 
         public static bool IsFunctionKeysDisplayed => OptionsModel.Instance.IsFunctionKeysDisplayed;
         public static bool IsCommandLineDisplayed => OptionsModel.Instance.IsCommandLineDisplayed;
@@ -379,7 +383,8 @@ namespace SmartCommander.ViewModels
                     return;
                 }
 
-                long totalSize = await _fs.GetTotalSizeAsync(items.Select(i => (i.FullName, i.IsFolder)).ToList());
+                var zipItems = items.Select(i => (i.FullName, i.IsFolder)).ToList();
+                long totalSize = await _fs.GetTotalSizeAsync(zipItems);
                 string description = string.Format(Resources.OperationZipDescription,
                     DescribeItems(items.Count, items[0].Name), zipName);
                 _ = RunZipAsync();
@@ -387,13 +392,91 @@ namespace SmartCommander.ViewModels
                 async Task RunZipAsync()
                 {
                     await RunOperationAndRefreshAsync(description, "Zip",
-                        (progress, ct) => Task.Run(() => ZipCore(items, zipName, totalSize, progress, ct), ct),
+                        (progress, ct) => CreateZipWork(zipItems, zipName, ZipCompressionLevel.Normal, null,
+                            totalSize, progress, ct),
                         pane);
                 }
             }
             catch (Exception ex)
             {
                 Log.Error(ex, "Zip failed");
+            }
+        }
+
+        // Mirrors the old ZipCore catch, now at the call site: the service throws on failure
+        // (no message boxes of its own), cancellation propagates untouched.
+        private async Task CreateZipWork(IReadOnlyList<(string FullName, bool IsFolder)> items, string zipName,
+            ZipCompressionLevel level, string? password, long totalSize, IProgress<int> progress, CancellationToken ct)
+        {
+            try
+            {
+                await _archives.CreateZipAsync(items, zipName, level, password, totalSize, progress, ct);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Zip failed: {ZipName}", zipName);
+                MessageBox_Show(null, string.Format(Resources.CantCreateArchive, zipName), Resources.Alert);
+            }
+        }
+
+        // "Zip with options…" - same target archive as Zip(), but a dialog first picks the
+        // compression level and an optional AES-256 password. A blank password produces a
+        // plain zip identical to what Zip() would make at that level.
+        public async Task ZipWithOptions()
+        {
+            if (SelectedPane.CurrentItems.Count < 1)
+            {
+                return;
+            }
+
+            try
+            {
+                var pane = SelectedPane;
+                var items = pane.CurrentItems.Select(i => (i.FullName, i.IsFolder, i.Name)).ToList();
+                var zipName = Path.Combine(pane.CurrentDirectory, items[0].Name + ".zip");
+                if (File.Exists(zipName))
+                {
+                    MessageBox_Show(null, string.Format(Resources.ArchiveExists, zipName), Resources.Alert);
+                    return;
+                }
+
+                var result = await ShowZipOptionsDialog.Handle(new ZipOptionsViewModel());
+                if (result is null || !result.IsConfirmed)
+                {
+                    return;
+                }
+
+                // Re-check: the dialog above can sit open for a long time, and CreateZipAsync
+                // opens the target with FileMode.CreateNew (it would throw rather than clobber),
+                // so surface the collision here as the normal "already exists" message instead.
+                if (File.Exists(zipName))
+                {
+                    MessageBox_Show(null, string.Format(Resources.ArchiveExists, zipName), Resources.Alert);
+                    return;
+                }
+
+                var level = result.Level;
+                var password = result.PasswordOrNull;
+                var zipItems = items.Select(i => (i.FullName, i.IsFolder)).ToList();
+                long totalSize = await _fs.GetTotalSizeAsync(zipItems);
+                string description = string.Format(Resources.OperationZipDescription,
+                    DescribeItems(items.Count, items[0].Name), zipName);
+                _ = RunZipAsync();
+
+                async Task RunZipAsync()
+                {
+                    await RunOperationAndRefreshAsync(description, "Zip",
+                        (progress, ct) => CreateZipWork(zipItems, zipName, level, password, totalSize, progress, ct),
+                        pane);
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "ZipWithOptions failed");
             }
         }
 
@@ -421,13 +504,62 @@ namespace SmartCommander.ViewModels
                     return;
                 }
 
+                bool encrypted;
+                try
+                {
+                    encrypted = await Task.Run(() => _archives.IsEncrypted(archiveFullName));
+                }
+                catch (Exception ex)
+                {
+                    Log.Error(ex, "Unzip failed reading archive: {ArchiveFullName}", archiveFullName);
+                    MessageBox_Show(null, string.Format(Resources.CantExtractArchive, archiveFullName), Resources.Alert);
+                    return;
+                }
+
+                // Encrypted archive: prompt for the password before launching anything, re-prompting
+                // on a wrong entry. Cancel aborts with nothing added to ActiveOperations.
+                string? password = null;
+                if (encrypted)
+                {
+                    int attempt = 0;
+                    while (true)
+                    {
+                        var prompt = await ShowPasswordPromptDialog.Handle(new PasswordPromptViewModel(retry: attempt > 0));
+                        if (prompt is null || !prompt.IsConfirmed)
+                        {
+                            return;
+                        }
+
+                        var candidate = prompt.Password;
+                        bool verified;
+                        try
+                        {
+                            verified = await Task.Run(() => _archives.VerifyPassword(archiveFullName, candidate));
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.Error(ex, "Unzip failed verifying password: {ArchiveFullName}", archiveFullName);
+                            MessageBox_Show(null, string.Format(Resources.CantExtractArchive, archiveFullName), Resources.Alert);
+                            return;
+                        }
+
+                        if (verified)
+                        {
+                            password = candidate;
+                            break;
+                        }
+
+                        attempt++;
+                    }
+                }
+
                 string description = string.Format(Resources.OperationUnzipDescription, archiveName, destDir);
                 _ = RunUnzipAsync();
 
                 async Task RunUnzipAsync()
                 {
                     await RunOperationAndRefreshAsync(description, "Unzip",
-                        (progress, ct) => Task.Run(() => UnzipCore(archiveFullName, destDir, progress, ct), ct),
+                        (progress, ct) => ExtractZipWork(archiveFullName, destDir, password, progress, ct),
                         pane);
                 }
             }
@@ -437,114 +569,22 @@ namespace SmartCommander.ViewModels
             }
         }
 
-        // Extracted entry-by-entry (instead of one ZipFile.ExtractToDirectory call) so
-        // cancellation takes effect between entries; ExtractToDirectory itself is not
-        // cancellable mid-call.
-        private void UnzipCore(string archiveFullName, string destDir, IProgress<int> progress, CancellationToken ct)
+        // Mirrors the old UnzipCore catch, now at the call site.
+        private async Task ExtractZipWork(string archiveFullName, string destDir, string? password,
+            IProgress<int> progress, CancellationToken ct)
         {
-            ct.ThrowIfCancellationRequested();
-
             try
             {
-                progress.Report(0);
-                Directory.CreateDirectory(destDir);
-                string destDirFull = Path.GetFullPath(destDir + Path.DirectorySeparatorChar);
-
-                using var archive = ZipFile.OpenRead(archiveFullName);
-                var entries = archive.Entries;
-                int total = entries.Count;
-                int done = 0;
-                foreach (var entry in entries)
-                {
-                    ct.ThrowIfCancellationRequested();
-                    string destPath = Path.GetFullPath(Path.Combine(destDir, entry.FullName));
-                    if (!destPath.StartsWith(destDirFull, StringComparison.Ordinal))
-                    {
-                        throw new IOException($"Zip entry is outside the target directory: {entry.FullName}");
-                    }
-
-                    if (entry.Name.Length == 0)
-                    {
-                        Directory.CreateDirectory(destPath);
-                    }
-                    else
-                    {
-                        Directory.CreateDirectory(Path.GetDirectoryName(destPath)!);
-                        entry.ExtractToFile(destPath, overwrite: true);
-                    }
-
-                    done++;
-                    progress.Report(total == 0 ? 100 : done * 100 / total);
-                }
+                await _archives.ExtractZipAsync(archiveFullName, destDir, password, progress, ct);
             }
-            catch (OperationCanceledException) { throw; }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
             catch (Exception ex)
             {
                 Log.Error(ex, "Unzip failed: {ArchiveFullName}", archiveFullName);
                 MessageBox_Show(null, string.Format(Resources.CantExtractArchive, archiveFullName), Resources.Alert);
-            }
-        }
-
-        private void ZipCore(List<(string FullName, bool IsFolder, string Name)> snapshot, string zipName, long totalSize, IProgress<int> progress, CancellationToken ct)
-        {
-            ct.ThrowIfCancellationRequested();
-            if (snapshot.Count < 1)
-            {
-                return;
-            }
-
-            try
-            {
-                progress.Report(0);
-                long processedSize = 0;
-
-                List<Tuple<string, string>> itemsToProcess = new();
-                foreach (var item in snapshot)
-                {
-                    itemsToProcess.Add(Tuple.Create("", item.FullName));
-                }
-
-                using (var zip = ZipFile.Open(zipName, ZipArchiveMode.Create))
-                {
-                    while (itemsToProcess.Count > 0)
-                    {
-                        ct.ThrowIfCancellationRequested();
-                        var item = itemsToProcess[0];
-                        var entryPath = item.Item1 as string;
-                        var path = item.Item2 as string;
-                        if (Directory.Exists(path))
-                        {
-                            var newEntryPath = Path.Combine(entryPath, new DirectoryInfo(path).Name);
-                            foreach (var folder in Directory.GetDirectories(path))
-                            {
-                                itemsToProcess.Add(Tuple.Create(newEntryPath, folder));
-                            }
-                            foreach (var file in Directory.GetFiles(path))
-                            {
-                                itemsToProcess.Add(Tuple.Create(newEntryPath, file));
-                            }
-                        }
-                        else if (File.Exists(path))
-                        {
-                            processedSize += new FileInfo(path).Length;
-                            zip.CreateEntryFromFile(sourceFileName: path,
-                                entryName: Path.Combine(item.Item1, Path.GetFileName(path)),
-                                CompressionLevel.Optimal);
-                        }
-
-                        itemsToProcess.Remove(item);
-
-                        progress.Report(totalSize == 0 ? 0 : (int)(processedSize * 100 / totalSize));
-                    }
-                }
-
-                progress.Report(100);
-            }
-            catch (OperationCanceledException) { throw; }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Zip failed: {ZipName}", zipName);
-                MessageBox_Show(null, string.Format(Resources.CantCreateArchive, zipName), Resources.Alert);
             }
         }
 

--- a/src/SmartCommander/ViewModels/PasswordPromptViewModel.cs
+++ b/src/SmartCommander/ViewModels/PasswordPromptViewModel.cs
@@ -1,0 +1,50 @@
+using Avalonia.Controls;
+using ReactiveUI;
+using System.Reactive;
+
+namespace SmartCommander.ViewModels
+{
+    // Prompt shown before extracting an encrypted archive. Re-shown in a loop
+    // (with Retry = true) each time the entered password is rejected.
+    public class PasswordPromptViewModel : ViewModelBase
+    {
+        public PasswordPromptViewModel(bool retry = false)
+        {
+            Retry = retry;
+            OKCommand = ReactiveCommand.Create<Window>(SaveClose);
+            CancelCommand = ReactiveCommand.Create<Window>(Close);
+        }
+
+        public bool Retry { get; }
+
+        private string _password = "";
+        public string Password
+        {
+            get => _password;
+            set { _password = value; this.RaisePropertyChanged(nameof(Password)); }
+        }
+
+        private bool _revealPassword;
+        public bool RevealPassword
+        {
+            get => _revealPassword;
+            set { _revealPassword = value; this.RaisePropertyChanged(nameof(RevealPassword)); }
+        }
+
+        public bool IsConfirmed { get; private set; }
+
+        public ReactiveCommand<Window, Unit> OKCommand { get; }
+        public ReactiveCommand<Window, Unit> CancelCommand { get; }
+
+        private void SaveClose(Window window)
+        {
+            IsConfirmed = true;
+            window?.Close(this);
+        }
+
+        private void Close(Window window)
+        {
+            window?.Close(this);
+        }
+    }
+}

--- a/src/SmartCommander/ViewModels/ZipOptionsViewModel.cs
+++ b/src/SmartCommander/ViewModels/ZipOptionsViewModel.cs
@@ -1,0 +1,106 @@
+using Avalonia.Controls;
+using ReactiveUI;
+using SmartCommander.Assets;
+using SmartCommander.Services;
+using System.Collections.Generic;
+using System.Reactive;
+using System.Reactive.Linq;
+
+namespace SmartCommander.ViewModels
+{
+    // One row in the compression-level dropdown: the enum value plus its localized label.
+    public class ZipLevelOption
+    {
+        public ZipLevelOption(ZipCompressionLevel level, string name)
+        {
+            Level = level;
+            Name = name;
+        }
+
+        public ZipCompressionLevel Level { get; }
+        public string Name { get; }
+    }
+
+    public class ZipOptionsViewModel : ViewModelBase
+    {
+        public ZipOptionsViewModel()
+        {
+            LevelOptions = new List<ZipLevelOption>
+            {
+                new(ZipCompressionLevel.Store, Resources.CompressionStore),
+                new(ZipCompressionLevel.Fastest, Resources.CompressionFastest),
+                new(ZipCompressionLevel.Normal, Resources.CompressionNormal),
+                new(ZipCompressionLevel.Maximum, Resources.CompressionMaximum)
+            };
+            _selectedLevel = LevelOptions[2]; // Normal
+
+            var canOk = this.WhenAnyValue(x => x.Password, x => x.ConfirmPassword, (p, c) => p == c);
+            OKCommand = ReactiveCommand.Create<Window>(SaveClose, canOk);
+            CancelCommand = ReactiveCommand.Create<Window>(Close);
+        }
+
+        private string _password = "";
+        public string Password
+        {
+            get => _password;
+            set
+            {
+                _password = value;
+                this.RaisePropertyChanged(nameof(Password));
+                this.RaisePropertyChanged(nameof(ShowMismatch));
+            }
+        }
+
+        private bool _revealPassword;
+        public bool RevealPassword
+        {
+            get => _revealPassword;
+            set { _revealPassword = value; this.RaisePropertyChanged(nameof(RevealPassword)); }
+        }
+
+        private string _confirmPassword = "";
+        public string ConfirmPassword
+        {
+            get => _confirmPassword;
+            set
+            {
+                _confirmPassword = value;
+                this.RaisePropertyChanged(nameof(ConfirmPassword));
+                this.RaisePropertyChanged(nameof(ShowMismatch));
+            }
+        }
+
+        public IReadOnlyList<ZipLevelOption> LevelOptions { get; }
+
+        private ZipLevelOption _selectedLevel;
+        public ZipLevelOption SelectedLevel
+        {
+            get => _selectedLevel;
+            set { _selectedLevel = value; this.RaisePropertyChanged(nameof(SelectedLevel)); }
+        }
+
+        // Shown inline in red once the confirm field has content that doesn't match.
+        public bool ShowMismatch => !string.IsNullOrEmpty(ConfirmPassword) && Password != ConfirmPassword;
+
+        public ZipCompressionLevel Level => SelectedLevel.Level;
+
+        // Empty password => plain (unencrypted) zip.
+        public string? PasswordOrNull => string.IsNullOrEmpty(Password) ? null : Password;
+
+        public bool IsConfirmed { get; private set; }
+
+        public ReactiveCommand<Window, Unit> OKCommand { get; }
+        public ReactiveCommand<Window, Unit> CancelCommand { get; }
+
+        private void SaveClose(Window window)
+        {
+            IsConfirmed = true;
+            window?.Close(this);
+        }
+
+        private void Close(Window window)
+        {
+            window?.Close(this);
+        }
+    }
+}

--- a/src/SmartCommander/Views/FilesPane.axaml
+++ b/src/SmartCommander/Views/FilesPane.axaml
@@ -129,6 +129,9 @@
 					<MenuItem Header="{x:Static assets:Resources.Zip}"
                               IsVisible="{Binding ShowZip, Mode=TwoWay}"
                               Command="{Binding ZipCommand}" />
+					<MenuItem Header="{x:Static assets:Resources.ZipWithOptions}"
+                              IsVisible="{Binding ShowZip, Mode=TwoWay}"
+                              Command="{Binding ZipWithOptionsCommand}" />
 					<MenuItem Header="{x:Static assets:Resources.Unzip}"
                               IsVisible="{Binding ShowUnzip, Mode=TwoWay}"
                               Command="{Binding UnzipCommand}" />

--- a/src/SmartCommander/Views/MainWindow.axaml.cs
+++ b/src/SmartCommander/Views/MainWindow.axaml.cs
@@ -43,6 +43,12 @@ namespace SmartCommander.Views
             this.WhenActivated(d => d(ViewModel!.ShowFtpConnectDialog.RegisterHandler(
                 interaction => DoShowDialogAsync<FtpConnectViewModel, FtpConnectWindow>(interaction)
             )));
+            this.WhenActivated(d => d(ViewModel!.ShowZipOptionsDialog.RegisterHandler(
+                interaction => DoShowDialogAsync<ZipOptionsViewModel, ZipOptionsWindow>(interaction)
+            )));
+            this.WhenActivated(d => d(ViewModel!.ShowPasswordPromptDialog.RegisterHandler(
+                interaction => DoShowDialogAsync<PasswordPromptViewModel, PasswordPromptWindow>(interaction)
+            )));
 
             operationsWindow = new OperationsWindow();
 

--- a/src/SmartCommander/Views/PasswordPromptWindow.axaml
+++ b/src/SmartCommander/Views/PasswordPromptWindow.axaml
@@ -1,0 +1,37 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:CompileBindings="False"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d" d:DesignWidth="380" d:DesignHeight="210"
+        Width="380" Height="210"
+        x:Class="SmartCommander.Views.PasswordPromptWindow"
+        WindowStartupLocation="CenterOwner"
+        ShowInTaskbar="False"
+        xmlns:assets="clr-namespace:SmartCommander.Assets"
+        Icon="/Assets/main.ico"
+        CanResize="False"
+        Title="{x:Static assets:Resources.Password}">
+	<Grid Margin="15" RowDefinitions="*,Auto">
+		<StackPanel Grid.Row="0" Spacing="10">
+			<TextBlock Text="{x:Static assets:Resources.EnterArchivePassword}"/>
+
+			<TextBox Name="PasswordTextBox"
+					 Text="{Binding Password, Mode=TwoWay}" PasswordChar="●"
+					 RevealPassword="{Binding RevealPassword}"/>
+
+			<CheckBox IsChecked="{Binding RevealPassword, Mode=TwoWay}"
+					  Content="{x:Static assets:Resources.ShowPassword}"/>
+
+			<TextBlock Foreground="Red" IsVisible="{Binding Retry}"
+					   Text="{x:Static assets:Resources.WrongArchivePassword}"/>
+		</StackPanel>
+
+		<StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+			<Button Margin="5,0,5,0" Command="{Binding OKCommand}" CommandParameter="{Binding $parent[Window]}" IsDefault="True"
+					Content="{x:Static assets:Resources.OK}"/>
+			<Button Margin="5,0,0,0" Command="{Binding CancelCommand}" CommandParameter="{Binding $parent[Window]}" IsCancel="True"
+					Content="{x:Static assets:Resources.Cancel}"/>
+		</StackPanel>
+	</Grid>
+</Window>

--- a/src/SmartCommander/Views/PasswordPromptWindow.axaml.cs
+++ b/src/SmartCommander/Views/PasswordPromptWindow.axaml.cs
@@ -1,0 +1,13 @@
+using Avalonia.Controls;
+
+namespace SmartCommander.Views
+{
+    public partial class PasswordPromptWindow : Window
+    {
+        public PasswordPromptWindow()
+        {
+            InitializeComponent();
+            Opened += (s, e) => PasswordTextBox.Focus();
+        }
+    }
+}

--- a/src/SmartCommander/Views/ZipOptionsWindow.axaml
+++ b/src/SmartCommander/Views/ZipOptionsWindow.axaml
@@ -1,0 +1,68 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:CompileBindings="False"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        mc:Ignorable="d" d:DesignWidth="420" d:DesignHeight="280"
+        Width="420" Height="280"
+        x:Class="SmartCommander.Views.ZipOptionsWindow"
+        WindowStartupLocation="CenterOwner"
+        ShowInTaskbar="False"
+        xmlns:assets="clr-namespace:SmartCommander.Assets"
+        Icon="/Assets/main.ico"
+        CanResize="False"
+        Title="{x:Static assets:Resources.ZipOptionsTitle}">
+	<Grid Margin="15" RowDefinitions="*,Auto">
+		<Grid Grid.Row="0">
+			<Grid.RowDefinitions>
+				<RowDefinition Height="Auto"/>
+				<RowDefinition Height="Auto"/>
+				<RowDefinition Height="Auto"/>
+				<RowDefinition Height="Auto"/>
+				<RowDefinition Height="Auto"/>
+			</Grid.RowDefinitions>
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition Width="Auto"/>
+				<ColumnDefinition Width="*"/>
+			</Grid.ColumnDefinitions>
+
+			<TextBlock Grid.Row="0" Grid.Column="0" Margin="0,0,10,10" VerticalAlignment="Center"
+					   Text="{x:Static assets:Resources.Password}"/>
+			<TextBox Grid.Row="0" Grid.Column="1" Margin="0,0,0,10" Name="PasswordTextBox"
+					 Text="{Binding Password, Mode=TwoWay}" PasswordChar="●"
+					 RevealPassword="{Binding RevealPassword}"/>
+
+			<TextBlock Grid.Row="1" Grid.Column="0" Margin="0,0,10,10" VerticalAlignment="Center"
+					   Text="{x:Static assets:Resources.ConfirmPassword}"/>
+			<TextBox Grid.Row="1" Grid.Column="1" Margin="0,0,0,10"
+					 Text="{Binding ConfirmPassword, Mode=TwoWay}" PasswordChar="●"
+					 RevealPassword="{Binding RevealPassword}"/>
+
+			<CheckBox Grid.Row="2" Grid.Column="1" Margin="0,0,0,10"
+					  IsChecked="{Binding RevealPassword, Mode=TwoWay}"
+					  Content="{x:Static assets:Resources.ShowPassword}"/>
+
+			<TextBlock Grid.Row="3" Grid.Column="1" Margin="0,0,0,10" Foreground="Red"
+					   IsVisible="{Binding ShowMismatch}"
+					   Text="{x:Static assets:Resources.PasswordsDoNotMatch}"/>
+
+			<TextBlock Grid.Row="4" Grid.Column="0" Margin="0,0,10,10" VerticalAlignment="Center"
+					   Text="{x:Static assets:Resources.CompressionLevel}"/>
+			<ComboBox Grid.Row="4" Grid.Column="1" Margin="0,0,0,10" HorizontalAlignment="Stretch"
+					  ItemsSource="{Binding LevelOptions}" SelectedItem="{Binding SelectedLevel, Mode=TwoWay}">
+				<ComboBox.ItemTemplate>
+					<DataTemplate>
+						<TextBlock Text="{Binding Name}"/>
+					</DataTemplate>
+				</ComboBox.ItemTemplate>
+			</ComboBox>
+		</Grid>
+
+		<StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+			<Button Margin="5,0,5,0" Command="{Binding OKCommand}" CommandParameter="{Binding $parent[Window]}" IsDefault="True"
+					Content="{x:Static assets:Resources.OK}"/>
+			<Button Margin="5,0,0,0" Command="{Binding CancelCommand}" CommandParameter="{Binding $parent[Window]}" IsCancel="True"
+					Content="{x:Static assets:Resources.Cancel}"/>
+		</StackPanel>
+	</Grid>
+</Window>

--- a/src/SmartCommander/Views/ZipOptionsWindow.axaml.cs
+++ b/src/SmartCommander/Views/ZipOptionsWindow.axaml.cs
@@ -1,0 +1,13 @@
+using Avalonia.Controls;
+
+namespace SmartCommander.Views
+{
+    public partial class ZipOptionsWindow : Window
+    {
+        public ZipOptionsWindow()
+        {
+            InitializeComponent();
+            Opened += (s, e) => PasswordTextBox.Focus();
+        }
+    }
+}


### PR DESCRIPTION
- New "Zip with options…" context-menu item next to "Zip". Opens a dialog:   masked Password + Confirm password (blank = no encryption, with a "Show password"  toggle), and a compression-level dropdown - Store / Fastest / Normal / Maximum  (deflate 0 / 1 / 6 / 9), default Normal.
- Plain "Zip" is unchanged: no dialog, instant name.zip, no password.
- Encrypted archive is detected on Unzip; a password prompt appears, re-prompting on a wrong entry until it verifies or the user cancels.