### PR TITLE
Add checksum / hash tools for local files.

### DIFF
--- a/src/SmartCommander.Tests/ChecksumServiceTests.cs
+++ b/src/SmartCommander.Tests/ChecksumServiceTests.cs
@@ -1,0 +1,137 @@
+using SmartCommander.Services;
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SmartCommander.Tests
+{
+    // Integration tests against a temp directory (real file I/O), like ArchiveServiceTests.
+    public class ChecksumServiceTests : IDisposable
+    {
+        private readonly string _root;
+        private readonly ChecksumService _svc = new();
+        private static readonly IProgress<int> NoProgress = new Progress<int>();
+
+        // Known NIST/RFC vectors.
+        private const string EmptyMd5 = "d41d8cd98f00b204e9800998ecf8427e";
+        private const string EmptySha1 = "da39a3ee5e6b4b0d3255bfef95601890afd80709";
+        private const string EmptySha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+        private const string AbcMd5 = "900150983cd24fb0d6963f7d28e17f72";
+        private const string AbcSha1 = "a9993e364706816aba3e25717850c26c9cd0d89d";
+        private const string AbcSha256 = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+
+        public ChecksumServiceTests()
+        {
+            _root = Path.Combine(Path.GetTempPath(), "SCChecksumTests_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_root);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(_root))
+            {
+                Directory.Delete(_root, recursive: true);
+            }
+        }
+
+        private string WriteFile(string name, byte[] content)
+        {
+            var path = Path.Combine(_root, name);
+            File.WriteAllBytes(path, content);
+            return path;
+        }
+
+        [Fact]
+        public async Task Compute_EmptyFile_MatchesKnownVectors()
+        {
+            var path = WriteFile("empty.bin", Array.Empty<byte>());
+
+            var result = await _svc.ComputeAsync(path, NoProgress, CancellationToken.None);
+
+            Assert.Equal(EmptyMd5, result.Md5);
+            Assert.Equal(EmptySha1, result.Sha1);
+            Assert.Equal(EmptySha256, result.Sha256);
+        }
+
+        [Fact]
+        public async Task Compute_AbcFile_MatchesKnownVectors()
+        {
+            var path = WriteFile("abc.txt", Encoding.ASCII.GetBytes("abc"));
+
+            var result = await _svc.ComputeAsync(path, NoProgress, CancellationToken.None);
+
+            Assert.Equal(AbcMd5, result.Md5);
+            Assert.Equal(AbcSha1, result.Sha1);
+            Assert.Equal(AbcSha256, result.Sha256);
+        }
+
+        [Fact]
+        public async Task Compute_LargeFile_ReportsProgressAndFinishesAtHundred()
+        {
+            // A few MB so the streaming loop runs over many buffers.
+            var bytes = new byte[5 * 1024 * 1024];
+            new Random(1).NextBytes(bytes);
+            var path = WriteFile("large.bin", bytes);
+
+            var seen100 = new TaskCompletionSource();
+            var progress = new Progress<int>(p => { if (p == 100) { seen100.TrySetResult(); } });
+
+            var result = await _svc.ComputeAsync(path, progress, CancellationToken.None);
+            await seen100.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            Assert.Equal(32 * 2, result.Sha256.Length);
+            Assert.Equal(16 * 2, result.Md5.Length);
+            Assert.Equal(20 * 2, result.Sha1.Length);
+        }
+
+        [Fact]
+        public async Task Compute_AlreadyCancelledToken_Throws()
+        {
+            var path = WriteFile("x.bin", new byte[] { 1, 2, 3 });
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => _svc.ComputeAsync(path, NoProgress, cts.Token));
+        }
+
+        [Fact]
+        public async Task TryReadSidecar_NoSidecar_ReturnsNull()
+        {
+            var path = WriteFile("plain.bin", new byte[] { 9 });
+
+            Assert.Null(await _svc.TryReadSidecarAsync(path));
+        }
+
+        [Fact]
+        public async Task TryReadSidecar_Sha256Sidecar_ReturnsHashToken()
+        {
+            var path = WriteFile("dl.iso", new byte[] { 1 });
+            File.WriteAllText(path + ".sha256", AbcSha256 + " *dl.iso" + Environment.NewLine);
+
+            Assert.Equal(AbcSha256, await _svc.TryReadSidecarAsync(path));
+        }
+
+        [Fact]
+        public async Task TryReadSidecar_Md5Sidecar_ReturnsHashToken()
+        {
+            var path = WriteFile("dl2.iso", new byte[] { 1 });
+            File.WriteAllText(path + ".md5", AbcMd5 + "  dl2.iso\n");
+
+            Assert.Equal(AbcMd5, await _svc.TryReadSidecarAsync(path));
+        }
+
+        [Fact]
+        public async Task TryReadSidecar_PrefersSha256OverMd5()
+        {
+            var path = WriteFile("dl3.iso", new byte[] { 1 });
+            File.WriteAllText(path + ".md5", AbcMd5);
+            File.WriteAllText(path + ".sha256", AbcSha256);
+
+            Assert.Equal(AbcSha256, await _svc.TryReadSidecarAsync(path));
+        }
+    }
+}

--- a/src/SmartCommander/Assets/Resources.Designer.cs
+++ b/src/SmartCommander/Assets/Resources.Designer.cs
@@ -1238,5 +1238,68 @@ namespace SmartCommander.Assets {
                 return ResourceManager.GetString("ShowPassword", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Checksum….
+        /// </summary>
+        public static string Checksum {
+            get {
+                return ResourceManager.GetString("Checksum", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Checksum.
+        /// </summary>
+        public static string ChecksumTitle {
+            get {
+                return ResourceManager.GetString("ChecksumTitle", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Expected value.
+        /// </summary>
+        public static string ChecksumExpectedValue {
+            get {
+                return ResourceManager.GetString("ChecksumExpectedValue", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Auto-filled from a .sha256 / .sha1 / .md5 file next to this one, if present..
+        /// </summary>
+        public static string ChecksumSidecarHint {
+            get {
+                return ResourceManager.GetString("ChecksumSidecarHint", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Matches {0}.
+        /// </summary>
+        public static string ChecksumMatches {
+            get {
+                return ResourceManager.GetString("ChecksumMatches", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Does not match any computed hash.
+        /// </summary>
+        public static string ChecksumNoMatch {
+            get {
+                return ResourceManager.GetString("ChecksumNoMatch", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Computation cancelled.
+        /// </summary>
+        public static string ChecksumCancelled {
+            get {
+                return ResourceManager.GetString("ChecksumCancelled", resourceCulture);
+            }
+        }
     }
 }

--- a/src/SmartCommander/Assets/Resources.fr-FR.resx
+++ b/src/SmartCommander/Assets/Resources.fr-FR.resx
@@ -510,4 +510,25 @@
   <data name="ShowPassword" xml:space="preserve">
     <value>Afficher le mot de passe</value>
   </data>
+  <data name="Checksum" xml:space="preserve">
+    <value>Somme de contrôle…</value>
+  </data>
+  <data name="ChecksumTitle" xml:space="preserve">
+    <value>Somme de contrôle</value>
+  </data>
+  <data name="ChecksumExpectedValue" xml:space="preserve">
+    <value>Valeur attendue</value>
+  </data>
+  <data name="ChecksumSidecarHint" xml:space="preserve">
+    <value>Rempli automatiquement à partir d'un fichier .sha256 / .sha1 / .md5 adjacent, s'il existe.</value>
+  </data>
+  <data name="ChecksumMatches" xml:space="preserve">
+    <value>Correspond à {0}</value>
+  </data>
+  <data name="ChecksumNoMatch" xml:space="preserve">
+    <value>Ne correspond à aucune empreinte calculée</value>
+  </data>
+  <data name="ChecksumCancelled" xml:space="preserve">
+    <value>Calcul annulé</value>
+  </data>
 </root>

--- a/src/SmartCommander/Assets/Resources.resx
+++ b/src/SmartCommander/Assets/Resources.resx
@@ -510,4 +510,25 @@
   <data name="ShowPassword" xml:space="preserve">
     <value>Show password</value>
   </data>
+  <data name="Checksum" xml:space="preserve">
+    <value>Checksum…</value>
+  </data>
+  <data name="ChecksumTitle" xml:space="preserve">
+    <value>Checksum</value>
+  </data>
+  <data name="ChecksumExpectedValue" xml:space="preserve">
+    <value>Expected value</value>
+  </data>
+  <data name="ChecksumSidecarHint" xml:space="preserve">
+    <value>Auto-filled from a .sha256 / .sha1 / .md5 file next to this one, if present.</value>
+  </data>
+  <data name="ChecksumMatches" xml:space="preserve">
+    <value>Matches {0}</value>
+  </data>
+  <data name="ChecksumNoMatch" xml:space="preserve">
+    <value>Does not match any computed hash</value>
+  </data>
+  <data name="ChecksumCancelled" xml:space="preserve">
+    <value>Computation cancelled</value>
+  </data>
 </root>

--- a/src/SmartCommander/Assets/Resources.ru-RU.resx
+++ b/src/SmartCommander/Assets/Resources.ru-RU.resx
@@ -510,4 +510,25 @@
   <data name="ShowPassword" xml:space="preserve">
     <value>Показать пароль</value>
   </data>
+  <data name="Checksum" xml:space="preserve">
+    <value>Контрольная сумма…</value>
+  </data>
+  <data name="ChecksumTitle" xml:space="preserve">
+    <value>Контрольная сумма</value>
+  </data>
+  <data name="ChecksumExpectedValue" xml:space="preserve">
+    <value>Ожидаемое значение</value>
+  </data>
+  <data name="ChecksumSidecarHint" xml:space="preserve">
+    <value>Автоматически заполняется из файла .sha256 / .sha1 / .md5 рядом с этим файлом, если он есть.</value>
+  </data>
+  <data name="ChecksumMatches" xml:space="preserve">
+    <value>Совпадает с {0}</value>
+  </data>
+  <data name="ChecksumNoMatch" xml:space="preserve">
+    <value>Не совпадает ни с одной вычисленной хеш-суммой</value>
+  </data>
+  <data name="ChecksumCancelled" xml:space="preserve">
+    <value>Вычисление отменено</value>
+  </data>
 </root>

--- a/src/SmartCommander/Assets/Resources.sr-Cyrl-RS.resx
+++ b/src/SmartCommander/Assets/Resources.sr-Cyrl-RS.resx
@@ -510,4 +510,25 @@
   <data name="ShowPassword" xml:space="preserve">
     <value>Прикажи лозинку</value>
   </data>
+  <data name="Checksum" xml:space="preserve">
+    <value>Контролна сума…</value>
+  </data>
+  <data name="ChecksumTitle" xml:space="preserve">
+    <value>Контролна сума</value>
+  </data>
+  <data name="ChecksumExpectedValue" xml:space="preserve">
+    <value>Очекивана вредност</value>
+  </data>
+  <data name="ChecksumSidecarHint" xml:space="preserve">
+    <value>Аутоматски попуњено из .sha256 / .sha1 / .md5 датотеке поред ове, ако постоји.</value>
+  </data>
+  <data name="ChecksumMatches" xml:space="preserve">
+    <value>Одговара {0}</value>
+  </data>
+  <data name="ChecksumNoMatch" xml:space="preserve">
+    <value>Не одговара ниједној израчунатој хеш вредности</value>
+  </data>
+  <data name="ChecksumCancelled" xml:space="preserve">
+    <value>Израчунавање је отказано</value>
+  </data>
 </root>

--- a/src/SmartCommander/Assets/Resources.sr-Latn-ME.resx
+++ b/src/SmartCommander/Assets/Resources.sr-Latn-ME.resx
@@ -510,4 +510,25 @@
   <data name="ShowPassword" xml:space="preserve">
     <value>Prikaži lozinku</value>
   </data>
+  <data name="Checksum" xml:space="preserve">
+    <value>Kontrolna suma…</value>
+  </data>
+  <data name="ChecksumTitle" xml:space="preserve">
+    <value>Kontrolna suma</value>
+  </data>
+  <data name="ChecksumExpectedValue" xml:space="preserve">
+    <value>Očekivana vrednost</value>
+  </data>
+  <data name="ChecksumSidecarHint" xml:space="preserve">
+    <value>Automatski popunjeno iz .sha256 / .sha1 / .md5 datoteke pored ove, ako postoji.</value>
+  </data>
+  <data name="ChecksumMatches" xml:space="preserve">
+    <value>Odgovara {0}</value>
+  </data>
+  <data name="ChecksumNoMatch" xml:space="preserve">
+    <value>Ne odgovara nijednoj izračunatoj heš vrednosti</value>
+  </data>
+  <data name="ChecksumCancelled" xml:space="preserve">
+    <value>Izračunavanje je otkazano</value>
+  </data>
 </root>

--- a/src/SmartCommander/Services/ChecksumService.cs
+++ b/src/SmartCommander/Services/ChecksumService.cs
@@ -1,0 +1,106 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SmartCommander.Services
+{
+    // The three hashes computed for a file, lower-case hex.
+    public record ChecksumResult(string Md5, string Sha1, string Sha256);
+
+    // Streaming MD5 / SHA-1 / SHA-256 over a local file in a single pass, plus best-effort
+    // reading of a ".sha256" / ".sha1" / ".md5" sidecar sitting next to the file. Not part of
+    // IFileSystemService: like ArchiveService, hashing / verification I/O is the documented
+    // routing exception. Instance methods; the sync work runs via an internal Task.Run and
+    // throws on failure (no message boxes - callers catch and surface).
+    public class ChecksumService
+    {
+        private const int BufferSize = 1024 * 1024;
+
+        // Probed in this order; the first that exists and yields a token wins.
+        private static readonly string[] SidecarExtensions = { ".sha256", ".sha1", ".md5" };
+
+        // progress is reported 0..100 against the file length (0 and 100 always fire).
+        public Task<ChecksumResult> ComputeAsync(string path, IProgress<int> progress, CancellationToken ct)
+        {
+            return Task.Run(() => Compute(path, progress, ct), ct);
+        }
+
+        private static ChecksumResult Compute(string path, IProgress<int> progress, CancellationToken ct)
+        {
+            ct.ThrowIfCancellationRequested();
+
+            using var md5 = IncrementalHash.CreateHash(HashAlgorithmName.MD5);
+            using var sha1 = IncrementalHash.CreateHash(HashAlgorithmName.SHA1);
+            using var sha256 = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+
+            progress.Report(0);
+            using (var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read,
+                       BufferSize, FileOptions.SequentialScan))
+            {
+                long total = stream.Length;
+                long processed = 0;
+                int lastPercent = -1;
+                var buffer = new byte[BufferSize];
+                int read;
+                while ((read = stream.Read(buffer, 0, buffer.Length)) > 0)
+                {
+                    ct.ThrowIfCancellationRequested();
+                    md5.AppendData(buffer, 0, read);
+                    sha1.AppendData(buffer, 0, read);
+                    sha256.AppendData(buffer, 0, read);
+                    processed += read;
+                    int percent = total <= 0 ? 100 : (int)(processed * 100 / total);
+                    if (percent != lastPercent)
+                    {
+                        progress.Report(percent);
+                        lastPercent = percent;
+                    }
+                }
+            }
+
+            progress.Report(100);
+            return new ChecksumResult(
+                Convert.ToHexStringLower(md5.GetHashAndReset()),
+                Convert.ToHexStringLower(sha1.GetHashAndReset()),
+                Convert.ToHexStringLower(sha256.GetHashAndReset()));
+        }
+
+        // Looks for "<file>.sha256" / ".sha1" / ".md5" beside the target. Returns the first
+        // whitespace-delimited token of the first non-empty line - the usual
+        // "<hash> *filename" / "<hash>  filename" sidecar layout - or null if nothing usable
+        // is found. A missing / locked / garbage sidecar just means "no pre-fill".
+        public async Task<string?> TryReadSidecarAsync(string filePath, CancellationToken ct = default)
+        {
+            foreach (var ext in SidecarExtensions)
+            {
+                var sidecarPath = filePath + ext;
+                if (!File.Exists(sidecarPath))
+                {
+                    continue;
+                }
+                try
+                {
+                    var lines = await File.ReadAllLinesAsync(sidecarPath, ct);
+                    var line = lines.FirstOrDefault(l => !string.IsNullOrWhiteSpace(l));
+                    var token = line?.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+                    if (!string.IsNullOrEmpty(token))
+                    {
+                        return token;
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch
+                {
+                    // best effort - fall through to the next candidate extension
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/src/SmartCommander/ViewModels/ChecksumViewModel.cs
+++ b/src/SmartCommander/ViewModels/ChecksumViewModel.cs
@@ -1,0 +1,189 @@
+using Avalonia.Controls;
+using ReactiveUI;
+using Serilog;
+using SmartCommander.Assets;
+using SmartCommander.Services;
+using System;
+using System.Reactive;
+using System.Threading;
+using System.Threading.Tasks;
+using Path = System.IO.Path;
+
+namespace SmartCommander.ViewModels
+{
+    public enum ChecksumMatch { None, Match, NoMatch }
+
+    // Read-only dialog: computes MD5 / SHA-1 / SHA-256 for a single local file and, if an
+    // "Expected value" is supplied (typed, or pre-filled from a sidecar), reports whether it
+    // matches any of the three. Computation is streamed off-thread and can be cancelled.
+    public class ChecksumViewModel : ViewModelBase
+    {
+        private readonly ChecksumService _service;
+        private readonly string _filePath;
+        private readonly CancellationTokenSource _cts = new();
+
+        public ChecksumViewModel(string filePath, ChecksumService service)
+            : this(filePath, service, compute: true)
+        {
+        }
+
+        // Design-time only: no file I/O, no background computation.
+        public ChecksumViewModel()
+            : this("file.bin", new ChecksumService(), compute: false)
+        {
+        }
+
+        private ChecksumViewModel(string filePath, ChecksumService service, bool compute)
+        {
+            _filePath = filePath;
+            _service = service;
+            FileName = Path.GetFileName(filePath);
+
+            CancelCommand = ReactiveCommand.Create(() => _cts.Cancel());
+            CloseCommand = ReactiveCommand.Create<Window>(w => { _cts.Cancel(); w?.Close(); });
+
+            if (compute)
+            {
+                _ = RunAsync();
+            }
+            else
+            {
+                IsComputing = false;
+            }
+        }
+
+        public string FileName { get; }
+
+        private string _md5 = "";
+        public string Md5 { get => _md5; private set => this.RaiseAndSetIfChanged(ref _md5, value); }
+
+        private string _sha1 = "";
+        public string Sha1 { get => _sha1; private set => this.RaiseAndSetIfChanged(ref _sha1, value); }
+
+        private string _sha256 = "";
+        public string Sha256 { get => _sha256; private set => this.RaiseAndSetIfChanged(ref _sha256, value); }
+
+        private int _progress;
+        public int Progress { get => _progress; private set => this.RaiseAndSetIfChanged(ref _progress, value); }
+
+        private bool _isComputing = true;
+        public bool IsComputing
+        {
+            get => _isComputing;
+            private set => this.RaiseAndSetIfChanged(ref _isComputing, value);
+        }
+
+        private string _status = "";
+        public string Status
+        {
+            get => _status;
+            private set
+            {
+                this.RaiseAndSetIfChanged(ref _status, value);
+                this.RaisePropertyChanged(nameof(HasStatus));
+            }
+        }
+        public bool HasStatus => !string.IsNullOrEmpty(Status);
+
+        private string _expectedValue = "";
+        public string ExpectedValue
+        {
+            get => _expectedValue;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref _expectedValue, value);
+                UpdateMatch();
+            }
+        }
+
+        private ChecksumMatch _matchResult = ChecksumMatch.None;
+        public ChecksumMatch MatchResult
+        {
+            get => _matchResult;
+            private set
+            {
+                this.RaiseAndSetIfChanged(ref _matchResult, value);
+                this.RaisePropertyChanged(nameof(ShowMatch));
+                this.RaisePropertyChanged(nameof(ShowNoMatch));
+                this.RaisePropertyChanged(nameof(MatchText));
+            }
+        }
+
+        public bool ShowMatch => MatchResult == ChecksumMatch.Match;
+        public bool ShowNoMatch => MatchResult == ChecksumMatch.NoMatch;
+
+        private string _matchedAlgorithm = "";
+        public string MatchText => MatchResult == ChecksumMatch.Match
+            ? string.Format(Resources.ChecksumMatches, _matchedAlgorithm)
+            : Resources.ChecksumNoMatch;
+
+        public ReactiveCommand<Unit, Unit> CancelCommand { get; }
+        public ReactiveCommand<Window, Unit> CloseCommand { get; }
+
+        private async Task RunAsync()
+        {
+            try
+            {
+                var sidecar = await _service.TryReadSidecarAsync(_filePath, _cts.Token);
+                if (sidecar != null && string.IsNullOrEmpty(ExpectedValue))
+                {
+                    ExpectedValue = sidecar;
+                }
+
+                var progress = new Progress<int>(p => Progress = p);
+                var result = await _service.ComputeAsync(_filePath, progress, _cts.Token);
+                Md5 = result.Md5;
+                Sha1 = result.Sha1;
+                Sha256 = result.Sha256;
+            }
+            catch (OperationCanceledException)
+            {
+                Status = Resources.ChecksumCancelled;
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Checksum computation failed for {FilePath}", _filePath);
+                Status = DescribeException(ex);
+            }
+            finally
+            {
+                IsComputing = false;
+                UpdateMatch();
+            }
+        }
+
+        private void UpdateMatch()
+        {
+            var expected = (ExpectedValue ?? "").Trim();
+            if (expected.Length == 0 || string.IsNullOrEmpty(Sha256))
+            {
+                MatchResult = ChecksumMatch.None;
+                return;
+            }
+
+            // A pasted sidecar line is often "<hash> *filename"; compare on the first token.
+            var spaceIdx = expected.IndexOfAny(new[] { ' ', '\t' });
+            var token = spaceIdx >= 0 ? expected.Substring(0, spaceIdx) : expected;
+
+            if (token.Equals(Sha256, StringComparison.OrdinalIgnoreCase))
+            {
+                _matchedAlgorithm = "SHA-256";
+                MatchResult = ChecksumMatch.Match;
+            }
+            else if (token.Equals(Sha1, StringComparison.OrdinalIgnoreCase))
+            {
+                _matchedAlgorithm = "SHA-1";
+                MatchResult = ChecksumMatch.Match;
+            }
+            else if (token.Equals(Md5, StringComparison.OrdinalIgnoreCase))
+            {
+                _matchedAlgorithm = "MD5";
+                MatchResult = ChecksumMatch.Match;
+            }
+            else
+            {
+                MatchResult = ChecksumMatch.NoMatch;
+            }
+        }
+    }
+}

--- a/src/SmartCommander/ViewModels/FilesPaneViewModel.cs
+++ b/src/SmartCommander/ViewModels/FilesPaneViewModel.cs
@@ -92,6 +92,9 @@ namespace SmartCommander.ViewModels
 
         public bool ShowZip => IsRealItemSelected && !IsFtp && !IsUnzip;
         public bool ShowUnzip => IsRealItemSelected && !IsFtp && IsUnzip;
+        // Checksum is a single-local-file tool: hidden for folders, FTP, and multi-selection.
+        public bool ShowChecksum => IsRealItemSelected && !IsFtp && CurrentItem != null
+            && !CurrentItem.IsFolder && CurrentItems.Count <= 1;
         public bool CanShowMoreOptions => !IsFtp && IsWindows;
         public bool CanShowItemMoreOptions => IsRealItemSelected && CanShowMoreOptions;
         // Covers both ".." and no selection at all (e.g. an empty directory) - either way
@@ -167,6 +170,7 @@ namespace SmartCommander.ViewModels
             ZipCommand = ReactiveCommand.CreateFromTask(Zip);
             ZipWithOptionsCommand = ReactiveCommand.CreateFromTask(ZipWithOptions);
             UnzipCommand = ReactiveCommand.CreateFromTask(Unzip);
+            ChecksumCommand = ReactiveCommand.CreateFromTask(Checksum);
             CopyCommand = ReactiveCommand.CreateFromTask(Copy);
             CutCommand = ReactiveCommand.CreateFromTask(Cut);
             TransferCommand = ReactiveCommand.CreateFromTask(() => _mainVM.Copy());
@@ -193,6 +197,7 @@ namespace SmartCommander.ViewModels
         public ReactiveCommand<Unit, Unit>? ZipCommand { get; }
         public ReactiveCommand<Unit, Unit>? ZipWithOptionsCommand { get; }
         public ReactiveCommand<Unit, Unit>? UnzipCommand { get; }
+        public ReactiveCommand<Unit, Unit>? ChecksumCommand { get; }
         public ReactiveCommand<Unit, Unit>? CopyCommand { get; }
         public ReactiveCommand<Unit, Unit>? CutCommand { get; }
         public ReactiveCommand<Unit, Unit>? TransferCommand { get; }
@@ -484,6 +489,11 @@ namespace SmartCommander.ViewModels
         public Task Unzip()
         {
             return _mainVM.Unzip();
+        }
+
+        public Task Checksum()
+        {
+            return _mainVM.Checksum();
         }
 
         public Task Delete()

--- a/src/SmartCommander/ViewModels/MainWindowViewModel.cs
+++ b/src/SmartCommander/ViewModels/MainWindowViewModel.cs
@@ -25,6 +25,7 @@ namespace SmartCommander.ViewModels
     {
         private readonly IFileSystemService _fs;
         private readonly ArchiveService _archives = new();
+        private readonly ChecksumService _checksums = new();
 
         public MainWindowViewModel(IFileSystemService fs)
         {
@@ -37,6 +38,7 @@ namespace SmartCommander.ViewModels
             ShowFtpConnectDialog = new Interaction<FtpConnectViewModel, FtpConnectViewModel?>();
             ShowZipOptionsDialog = new Interaction<ZipOptionsViewModel, ZipOptionsViewModel?>();
             ShowPasswordPromptDialog = new Interaction<PasswordPromptViewModel, PasswordPromptViewModel?>();
+            ShowChecksumDialog = new Interaction<ChecksumViewModel, ChecksumViewModel?>();
 
             ExitCommand = ReactiveCommand.Create(Exit);
             SortNameCommand = ReactiveCommand.Create(SortName);
@@ -156,6 +158,7 @@ namespace SmartCommander.ViewModels
         public Interaction<FtpConnectViewModel, FtpConnectViewModel?> ShowFtpConnectDialog { get; }
         public Interaction<ZipOptionsViewModel, ZipOptionsViewModel?> ShowZipOptionsDialog { get; }
         public Interaction<PasswordPromptViewModel, PasswordPromptViewModel?> ShowPasswordPromptDialog { get; }
+        public Interaction<ChecksumViewModel, ChecksumViewModel?> ShowChecksumDialog { get; }
 
         public static bool IsFunctionKeysDisplayed => OptionsModel.Instance.IsFunctionKeysDisplayed;
         public static bool IsCommandLineDisplayed => OptionsModel.Instance.IsCommandLineDisplayed;
@@ -586,6 +589,20 @@ namespace SmartCommander.ViewModels
                 Log.Error(ex, "Unzip failed: {ArchiveFullName}", archiveFullName);
                 MessageBox_Show(null, string.Format(Resources.CantExtractArchive, archiveFullName), Resources.Alert);
             }
+        }
+
+        // Single local file only (the menu item is hidden otherwise). The dialog streams the
+        // hashes off-thread and shows them - no ActiveOperations entry, it's read-only and
+        // self-contained, and cancellation is handled inside the dialog.
+        public async Task Checksum()
+        {
+            var pane = SelectedPane;
+            var item = pane.CurrentItem;
+            if (item == null || item.IsFolder || item.FullName == ".." || pane.IsFtp)
+            {
+                return;
+            }
+            await ShowChecksumDialog.Handle(new ChecksumViewModel(item.FullName, _checksums));
         }
 
         public async Task Copy()

--- a/src/SmartCommander/Views/ChecksumWindow.axaml
+++ b/src/SmartCommander/Views/ChecksumWindow.axaml
@@ -1,0 +1,89 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:CompileBindings="False"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="using:SmartCommander.ViewModels"
+        mc:Ignorable="d" d:DesignWidth="640" d:DesignHeight="340"
+        Width="640" Height="340"
+        x:Class="SmartCommander.Views.ChecksumWindow"
+        WindowStartupLocation="CenterOwner"
+        ShowInTaskbar="False"
+        xmlns:assets="clr-namespace:SmartCommander.Assets"
+        Icon="/Assets/main.ico"
+        CanResize="False"
+        Title="{x:Static assets:Resources.ChecksumTitle}">
+
+	<Design.DataContext>
+		<vm:ChecksumViewModel/>
+	</Design.DataContext>
+
+	<Grid Margin="15" RowDefinitions="*,Auto">
+		<Grid Grid.Row="0">
+			<Grid.RowDefinitions>
+				<RowDefinition Height="Auto"/>
+				<RowDefinition Height="Auto"/>
+				<RowDefinition Height="Auto"/>
+				<RowDefinition Height="Auto"/>
+				<RowDefinition Height="Auto"/>
+				<RowDefinition Height="Auto"/>
+				<RowDefinition Height="Auto"/>
+				<RowDefinition Height="Auto"/>
+				<RowDefinition Height="Auto"/>
+			</Grid.RowDefinitions>
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition Width="Auto"/>
+				<ColumnDefinition Width="*"/>
+			</Grid.ColumnDefinitions>
+
+			<TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" Margin="0,0,0,12"
+					   FontWeight="Bold" TextTrimming="CharacterEllipsis"
+					   Text="{Binding FileName}"/>
+
+			<TextBlock Grid.Row="1" Grid.Column="0" Margin="0,0,10,8" VerticalAlignment="Center" Text="MD5"/>
+			<TextBox Grid.Row="1" Grid.Column="1" Margin="0,0,0,8" IsReadOnly="True"
+					 Text="{Binding Md5}"/>
+
+			<TextBlock Grid.Row="2" Grid.Column="0" Margin="0,0,10,8" VerticalAlignment="Center" Text="SHA-1"/>
+			<TextBox Grid.Row="2" Grid.Column="1" Margin="0,0,0,8" IsReadOnly="True"
+					 Text="{Binding Sha1}"/>
+
+			<TextBlock Grid.Row="3" Grid.Column="0" Margin="0,0,10,8" VerticalAlignment="Center" Text="SHA-256"/>
+			<TextBox Grid.Row="3" Grid.Column="1" Margin="0,0,0,8" IsReadOnly="True"
+					 Text="{Binding Sha256}"/>
+
+			<ProgressBar Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2" Margin="0,4,0,8"
+						 Minimum="0" Maximum="100" Value="{Binding Progress}"
+						 IsVisible="{Binding IsComputing}"/>
+
+			<TextBlock Grid.Row="5" Grid.Column="0" Grid.ColumnSpan="2" Margin="0,0,0,8"
+					   Foreground="Gray" TextWrapping="Wrap"
+					   IsVisible="{Binding HasStatus}" Text="{Binding Status}"/>
+
+			<TextBlock Grid.Row="6" Grid.Column="0" Margin="0,0,10,4" VerticalAlignment="Center"
+					   Text="{x:Static assets:Resources.ChecksumExpectedValue}"/>
+			<TextBox Grid.Row="6" Grid.Column="1" Margin="0,0,0,4"
+					 Text="{Binding ExpectedValue, Mode=TwoWay}"/>
+
+			<TextBlock Grid.Row="7" Grid.Column="1" Margin="0,0,0,8" FontSize="11"
+					   Foreground="Gray" TextWrapping="Wrap"
+					   Text="{x:Static assets:Resources.ChecksumSidecarHint}"/>
+
+			<TextBlock Grid.Row="8" Grid.Column="0" Grid.ColumnSpan="2"
+					   FontWeight="Bold" Foreground="Green" TextWrapping="Wrap"
+					   IsVisible="{Binding ShowMatch}" Text="{Binding MatchText}"/>
+			<TextBlock Grid.Row="8" Grid.Column="0" Grid.ColumnSpan="2"
+					   FontWeight="Bold" Foreground="Red" TextWrapping="Wrap"
+					   IsVisible="{Binding ShowNoMatch}" Text="{Binding MatchText}"/>
+		</Grid>
+
+		<StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,10,0,0">
+			<Button Margin="5,0,5,0" Command="{Binding CancelCommand}"
+					IsVisible="{Binding IsComputing}"
+					Content="{x:Static assets:Resources.Cancel}"/>
+			<Button Margin="5,0,0,0" Command="{Binding CloseCommand}" CommandParameter="{Binding $parent[Window]}"
+					IsDefault="True" IsCancel="True"
+					Content="{x:Static assets:Resources.OK}"/>
+		</StackPanel>
+	</Grid>
+</Window>

--- a/src/SmartCommander/Views/ChecksumWindow.axaml.cs
+++ b/src/SmartCommander/Views/ChecksumWindow.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+
+namespace SmartCommander.Views
+{
+    public partial class ChecksumWindow : Window
+    {
+        public ChecksumWindow()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/SmartCommander/Views/FilesPane.axaml
+++ b/src/SmartCommander/Views/FilesPane.axaml
@@ -135,6 +135,9 @@
 					<MenuItem Header="{x:Static assets:Resources.Unzip}"
                               IsVisible="{Binding ShowUnzip, Mode=TwoWay}"
                               Command="{Binding UnzipCommand}" />
+					<MenuItem Header="{x:Static assets:Resources.Checksum}"
+                              IsVisible="{Binding ShowChecksum}"
+                              Command="{Binding ChecksumCommand}" />
 					<MenuItem Header="{x:Static assets:Resources.MoreOptions}"
                               IsVisible="{Binding CanShowItemMoreOptions}"
                               Command="{Binding ShowMoreOptionsCommand}" />

--- a/src/SmartCommander/Views/MainWindow.axaml.cs
+++ b/src/SmartCommander/Views/MainWindow.axaml.cs
@@ -49,6 +49,9 @@ namespace SmartCommander.Views
             this.WhenActivated(d => d(ViewModel!.ShowPasswordPromptDialog.RegisterHandler(
                 interaction => DoShowDialogAsync<PasswordPromptViewModel, PasswordPromptWindow>(interaction)
             )));
+            this.WhenActivated(d => d(ViewModel!.ShowChecksumDialog.RegisterHandler(
+                interaction => DoShowDialogAsync<ChecksumViewModel, ChecksumWindow>(interaction)
+            )));
 
             operationsWindow = new OperationsWindow();
 


### PR DESCRIPTION
Adds a "Checksum..." item to the file context menu (after Unzip),
enabled only for a single selected local file. It opens a read-only
dialog showing MD5, SHA-1, and SHA-256 for the file:

- Streams the file once through three IncrementalHash instances,
  sync work in an internal Task.Run, 1 MB buffer, lowercase hex.
- Progress bar (0..100 by bytes) + Cancel; Close also cancels.
- Probes <file>.sha256 -> .sha1 -> .md5 sidecars; first hit pre-fills
  the expected-value box. Case-insensitive compare against SHA-256,
  then SHA-1, then MD5, with a green/red indicator naming the match.
- Hidden for folders, FTP panes, and multi-selection.

ChecksumService is the same documented direct-I/O exception as
ArchiveService (not routed through IFileSystemService). No
ActiveOperations entry - read-only, cancellation lives in the dialog.

Tests: 8 new ChecksumServiceTests (temp-dir integration - NIST/RFC
vectors, large-file progress, cancelled token, sidecar none/.sha256/
.md5/priority).