### PR TITLE
Properties dialog for a local file or folder.

### DIFF
--- a/src/SmartCommander.Tests/PropertiesServiceTests.cs
+++ b/src/SmartCommander.Tests/PropertiesServiceTests.cs
@@ -1,0 +1,153 @@
+using SmartCommander.Services;
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SmartCommander.Tests
+{
+    // Integration tests against a temp directory (real file I/O), like ChecksumServiceTests.
+    public class PropertiesServiceTests : IDisposable
+    {
+        private readonly string _root;
+        private readonly PropertiesService _svc = new();
+
+        public PropertiesServiceTests()
+        {
+            _root = Path.Combine(Path.GetTempPath(), "SCPropsTests_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(_root);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(_root))
+            {
+                // Clear any read-only bits a test set, so the recursive delete succeeds.
+                foreach (var f in Directory.EnumerateFiles(_root, "*", SearchOption.AllDirectories))
+                {
+                    try { File.SetAttributes(f, FileAttributes.Normal); } catch { }
+                }
+                Directory.Delete(_root, recursive: true);
+            }
+        }
+
+        private string WriteFile(string name, byte[] content)
+        {
+            var path = Path.Combine(_root, name);
+            File.WriteAllBytes(path, content);
+            return path;
+        }
+
+        [Fact]
+        public async Task Get_File_ReturnsSizeAndTimestamps()
+        {
+            var path = WriteFile("a.bin", new byte[123]);
+
+            var p = await _svc.GetAsync(path, isFolder: false);
+
+            Assert.False(p.IsFolder);
+            Assert.Equal(123, p.Size);
+            Assert.Equal(File.GetCreationTime(path), p.CreationTime);
+            Assert.Equal(File.GetLastWriteTime(path), p.LastWriteTime);
+        }
+
+        [Fact]
+        public async Task Get_ReadOnlyFile_ReportsReadOnly()
+        {
+            var path = WriteFile("ro.bin", new byte[] { 1 });
+            File.SetAttributes(path, File.GetAttributes(path) | FileAttributes.ReadOnly);
+
+            var p = await _svc.GetAsync(path, isFolder: false);
+
+            Assert.True(p.IsReadOnly);
+        }
+
+        [Fact]
+        public async Task ApplyAttributes_SetsAndClearsReadOnly()
+        {
+            var path = WriteFile("toggle.bin", new byte[] { 1 });
+
+            await _svc.ApplyAttributesAsync(path, readOnly: true, hidden: false);
+            Assert.True(File.GetAttributes(path).HasFlag(FileAttributes.ReadOnly));
+
+            await _svc.ApplyAttributesAsync(path, readOnly: false, hidden: false);
+            Assert.False(File.GetAttributes(path).HasFlag(FileAttributes.ReadOnly));
+        }
+
+        [Fact]
+        public async Task ApplyAttributes_HiddenIsWindowsOnly()
+        {
+            var path = WriteFile("hid.bin", new byte[] { 1 });
+
+            await _svc.ApplyAttributesAsync(path, readOnly: false, hidden: true);
+
+            var hidden = File.GetAttributes(path).HasFlag(FileAttributes.Hidden);
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Assert.True(hidden);
+            }
+            else
+            {
+                Assert.False(hidden);
+            }
+        }
+
+        [Fact]
+        public async Task ComputeFolderTally_CountsFilesFoldersAndBytes()
+        {
+            // root/f1.bin (10), root/sub/f2.bin (20), root/sub/nested/f3.bin (30)
+            WriteFile("f1.bin", new byte[10]);
+            Directory.CreateDirectory(Path.Combine(_root, "sub", "nested"));
+            File.WriteAllBytes(Path.Combine(_root, "sub", "f2.bin"), new byte[20]);
+            File.WriteAllBytes(Path.Combine(_root, "sub", "nested", "f3.bin"), new byte[30]);
+
+            var tally = await _svc.ComputeFolderTallyAsync(_root, null, CancellationToken.None);
+
+            Assert.Equal(3, tally.Files);
+            Assert.Equal(2, tally.Folders);
+            Assert.Equal(60, tally.Bytes);
+        }
+
+        [Fact]
+        public async Task ComputeFolderTally_EmptyFolder_IsAllZero()
+        {
+            var tally = await _svc.ComputeFolderTallyAsync(_root, null, CancellationToken.None);
+
+            Assert.Equal(0, tally.Files);
+            Assert.Equal(0, tally.Folders);
+            Assert.Equal(0, tally.Bytes);
+        }
+
+        [Fact]
+        public async Task ComputeFolderTally_ReportsFinalProgress()
+        {
+            WriteFile("f1.bin", new byte[5]);
+
+            FolderTally? last = null;
+            var progress = new Progress<FolderTally>(t => last = t);
+
+            var tally = await _svc.ComputeFolderTallyAsync(_root, progress, CancellationToken.None);
+
+            // The Progress callback marshals asynchronously; give it a moment to land.
+            for (var i = 0; i < 50 && last == null; i++)
+            {
+                await Task.Delay(10);
+            }
+
+            Assert.NotNull(last);
+            Assert.Equal(tally, last);
+        }
+
+        [Fact]
+        public async Task ComputeFolderTally_AlreadyCancelledToken_Throws()
+        {
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => _svc.ComputeFolderTallyAsync(_root, null, cts.Token));
+        }
+    }
+}

--- a/src/SmartCommander/Assets/Resources.Designer.cs
+++ b/src/SmartCommander/Assets/Resources.Designer.cs
@@ -1301,5 +1301,176 @@ namespace SmartCommander.Assets {
                 return ResourceManager.GetString("ChecksumCancelled", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Properties.
+        /// </summary>
+        public static string Properties {
+            get {
+                return ResourceManager.GetString("Properties", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Location.
+        /// </summary>
+        public static string PropertiesLocation {
+            get {
+                return ResourceManager.GetString("PropertiesLocation", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Type.
+        /// </summary>
+        public static string PropertiesType {
+            get {
+                return ResourceManager.GetString("PropertiesType", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to File.
+        /// </summary>
+        public static string PropertiesTypeFile {
+            get {
+                return ResourceManager.GetString("PropertiesTypeFile", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Folder.
+        /// </summary>
+        public static string PropertiesTypeFolder {
+            get {
+                return ResourceManager.GetString("PropertiesTypeFolder", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Contains.
+        /// </summary>
+        public static string PropertiesContains {
+            get {
+                return ResourceManager.GetString("PropertiesContains", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to {0:N0} files, {1:N0} folders.
+        /// </summary>
+        public static string PropertiesContainsFormat {
+            get {
+                return ResourceManager.GetString("PropertiesContainsFormat", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Created.
+        /// </summary>
+        public static string PropertiesCreated {
+            get {
+                return ResourceManager.GetString("PropertiesCreated", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Modified.
+        /// </summary>
+        public static string PropertiesModified {
+            get {
+                return ResourceManager.GetString("PropertiesModified", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Accessed.
+        /// </summary>
+        public static string PropertiesAccessed {
+            get {
+                return ResourceManager.GetString("PropertiesAccessed", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Attributes.
+        /// </summary>
+        public static string PropertiesAttributes {
+            get {
+                return ResourceManager.GetString("PropertiesAttributes", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Read-only.
+        /// </summary>
+        public static string PropertiesReadOnly {
+            get {
+                return ResourceManager.GetString("PropertiesReadOnly", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Hidden.
+        /// </summary>
+        public static string PropertiesHidden {
+            get {
+                return ResourceManager.GetString("PropertiesHidden", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Calculating….
+        /// </summary>
+        public static string PropertiesCalculating {
+            get {
+                return ResourceManager.GetString("PropertiesCalculating", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Cancelled.
+        /// </summary>
+        public static string PropertiesSizeCancelled {
+            get {
+                return ResourceManager.GetString("PropertiesSizeCancelled", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to {0} ({1:N0} bytes).
+        /// </summary>
+        public static string PropertiesSizeFormat {
+            get {
+                return ResourceManager.GetString("PropertiesSizeFormat", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Could not change attributes: {0}.
+        /// </summary>
+        public static string PropertiesApplyFailed {
+            get {
+                return ResourceManager.GetString("PropertiesApplyFailed", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Apply.
+        /// </summary>
+        public static string Apply {
+            get {
+                return ResourceManager.GetString("Apply", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Close.
+        /// </summary>
+        public static string Close {
+            get {
+                return ResourceManager.GetString("Close", resourceCulture);
+            }
+        }
     }
 }

--- a/src/SmartCommander/Assets/Resources.fr-FR.resx
+++ b/src/SmartCommander/Assets/Resources.fr-FR.resx
@@ -531,4 +531,61 @@
   <data name="ChecksumCancelled" xml:space="preserve">
     <value>Calcul annulé</value>
   </data>
+  <data name="Properties" xml:space="preserve">
+    <value>Propriétés</value>
+  </data>
+  <data name="PropertiesLocation" xml:space="preserve">
+    <value>Emplacement</value>
+  </data>
+  <data name="PropertiesType" xml:space="preserve">
+    <value>Type</value>
+  </data>
+  <data name="PropertiesTypeFile" xml:space="preserve">
+    <value>Fichier</value>
+  </data>
+  <data name="PropertiesTypeFolder" xml:space="preserve">
+    <value>Dossier</value>
+  </data>
+  <data name="PropertiesContains" xml:space="preserve">
+    <value>Contenu</value>
+  </data>
+  <data name="PropertiesContainsFormat" xml:space="preserve">
+    <value>{0:N0} fichiers, {1:N0} dossiers</value>
+  </data>
+  <data name="PropertiesCreated" xml:space="preserve">
+    <value>Créé</value>
+  </data>
+  <data name="PropertiesModified" xml:space="preserve">
+    <value>Modifié</value>
+  </data>
+  <data name="PropertiesAccessed" xml:space="preserve">
+    <value>Dernier accès</value>
+  </data>
+  <data name="PropertiesAttributes" xml:space="preserve">
+    <value>Attributs</value>
+  </data>
+  <data name="PropertiesReadOnly" xml:space="preserve">
+    <value>Lecture seule</value>
+  </data>
+  <data name="PropertiesHidden" xml:space="preserve">
+    <value>Caché</value>
+  </data>
+  <data name="PropertiesCalculating" xml:space="preserve">
+    <value>Calcul en cours…</value>
+  </data>
+  <data name="PropertiesSizeCancelled" xml:space="preserve">
+    <value>Annulé</value>
+  </data>
+  <data name="PropertiesSizeFormat" xml:space="preserve">
+    <value>{0} ({1:N0} octets)</value>
+  </data>
+  <data name="PropertiesApplyFailed" xml:space="preserve">
+    <value>Impossible de modifier les attributs : {0}</value>
+  </data>
+  <data name="Apply" xml:space="preserve">
+    <value>Appliquer</value>
+  </data>
+  <data name="Close" xml:space="preserve">
+    <value>Fermer</value>
+  </data>
 </root>

--- a/src/SmartCommander/Assets/Resources.resx
+++ b/src/SmartCommander/Assets/Resources.resx
@@ -531,4 +531,61 @@
   <data name="ChecksumCancelled" xml:space="preserve">
     <value>Computation cancelled</value>
   </data>
+  <data name="Properties" xml:space="preserve">
+    <value>Properties</value>
+  </data>
+  <data name="PropertiesLocation" xml:space="preserve">
+    <value>Location</value>
+  </data>
+  <data name="PropertiesType" xml:space="preserve">
+    <value>Type</value>
+  </data>
+  <data name="PropertiesTypeFile" xml:space="preserve">
+    <value>File</value>
+  </data>
+  <data name="PropertiesTypeFolder" xml:space="preserve">
+    <value>Folder</value>
+  </data>
+  <data name="PropertiesContains" xml:space="preserve">
+    <value>Contains</value>
+  </data>
+  <data name="PropertiesContainsFormat" xml:space="preserve">
+    <value>{0:N0} files, {1:N0} folders</value>
+  </data>
+  <data name="PropertiesCreated" xml:space="preserve">
+    <value>Created</value>
+  </data>
+  <data name="PropertiesModified" xml:space="preserve">
+    <value>Modified</value>
+  </data>
+  <data name="PropertiesAccessed" xml:space="preserve">
+    <value>Accessed</value>
+  </data>
+  <data name="PropertiesAttributes" xml:space="preserve">
+    <value>Attributes</value>
+  </data>
+  <data name="PropertiesReadOnly" xml:space="preserve">
+    <value>Read-only</value>
+  </data>
+  <data name="PropertiesHidden" xml:space="preserve">
+    <value>Hidden</value>
+  </data>
+  <data name="PropertiesCalculating" xml:space="preserve">
+    <value>Calculating…</value>
+  </data>
+  <data name="PropertiesSizeCancelled" xml:space="preserve">
+    <value>Cancelled</value>
+  </data>
+  <data name="PropertiesSizeFormat" xml:space="preserve">
+    <value>{0} ({1:N0} bytes)</value>
+  </data>
+  <data name="PropertiesApplyFailed" xml:space="preserve">
+    <value>Could not change attributes: {0}</value>
+  </data>
+  <data name="Apply" xml:space="preserve">
+    <value>Apply</value>
+  </data>
+  <data name="Close" xml:space="preserve">
+    <value>Close</value>
+  </data>
 </root>

--- a/src/SmartCommander/Assets/Resources.ru-RU.resx
+++ b/src/SmartCommander/Assets/Resources.ru-RU.resx
@@ -531,4 +531,61 @@
   <data name="ChecksumCancelled" xml:space="preserve">
     <value>Вычисление отменено</value>
   </data>
+  <data name="Properties" xml:space="preserve">
+    <value>Свойства</value>
+  </data>
+  <data name="PropertiesLocation" xml:space="preserve">
+    <value>Расположение</value>
+  </data>
+  <data name="PropertiesType" xml:space="preserve">
+    <value>Тип</value>
+  </data>
+  <data name="PropertiesTypeFile" xml:space="preserve">
+    <value>Файл</value>
+  </data>
+  <data name="PropertiesTypeFolder" xml:space="preserve">
+    <value>Папка</value>
+  </data>
+  <data name="PropertiesContains" xml:space="preserve">
+    <value>Содержимое</value>
+  </data>
+  <data name="PropertiesContainsFormat" xml:space="preserve">
+    <value>Файлов: {0:N0}, папок: {1:N0}</value>
+  </data>
+  <data name="PropertiesCreated" xml:space="preserve">
+    <value>Создан</value>
+  </data>
+  <data name="PropertiesModified" xml:space="preserve">
+    <value>Изменён</value>
+  </data>
+  <data name="PropertiesAccessed" xml:space="preserve">
+    <value>Открыт</value>
+  </data>
+  <data name="PropertiesAttributes" xml:space="preserve">
+    <value>Атрибуты</value>
+  </data>
+  <data name="PropertiesReadOnly" xml:space="preserve">
+    <value>Только для чтения</value>
+  </data>
+  <data name="PropertiesHidden" xml:space="preserve">
+    <value>Скрытый</value>
+  </data>
+  <data name="PropertiesCalculating" xml:space="preserve">
+    <value>Вычисление…</value>
+  </data>
+  <data name="PropertiesSizeCancelled" xml:space="preserve">
+    <value>Отменено</value>
+  </data>
+  <data name="PropertiesSizeFormat" xml:space="preserve">
+    <value>{0} ({1:N0} байт)</value>
+  </data>
+  <data name="PropertiesApplyFailed" xml:space="preserve">
+    <value>Не удалось изменить атрибуты: {0}</value>
+  </data>
+  <data name="Apply" xml:space="preserve">
+    <value>Применить</value>
+  </data>
+  <data name="Close" xml:space="preserve">
+    <value>Закрыть</value>
+  </data>
 </root>

--- a/src/SmartCommander/Assets/Resources.sr-Cyrl-RS.resx
+++ b/src/SmartCommander/Assets/Resources.sr-Cyrl-RS.resx
@@ -531,4 +531,61 @@
   <data name="ChecksumCancelled" xml:space="preserve">
     <value>Израчунавање је отказано</value>
   </data>
+  <data name="Properties" xml:space="preserve">
+    <value>Својства</value>
+  </data>
+  <data name="PropertiesLocation" xml:space="preserve">
+    <value>Локација</value>
+  </data>
+  <data name="PropertiesType" xml:space="preserve">
+    <value>Тип</value>
+  </data>
+  <data name="PropertiesTypeFile" xml:space="preserve">
+    <value>Датотека</value>
+  </data>
+  <data name="PropertiesTypeFolder" xml:space="preserve">
+    <value>Фасцикла</value>
+  </data>
+  <data name="PropertiesContains" xml:space="preserve">
+    <value>Садржај</value>
+  </data>
+  <data name="PropertiesContainsFormat" xml:space="preserve">
+    <value>{0:N0} датотека, {1:N0} фасцикли</value>
+  </data>
+  <data name="PropertiesCreated" xml:space="preserve">
+    <value>Направљено</value>
+  </data>
+  <data name="PropertiesModified" xml:space="preserve">
+    <value>Измењено</value>
+  </data>
+  <data name="PropertiesAccessed" xml:space="preserve">
+    <value>Приступљено</value>
+  </data>
+  <data name="PropertiesAttributes" xml:space="preserve">
+    <value>Атрибути</value>
+  </data>
+  <data name="PropertiesReadOnly" xml:space="preserve">
+    <value>Само за читање</value>
+  </data>
+  <data name="PropertiesHidden" xml:space="preserve">
+    <value>Скривено</value>
+  </data>
+  <data name="PropertiesCalculating" xml:space="preserve">
+    <value>Израчунавање…</value>
+  </data>
+  <data name="PropertiesSizeCancelled" xml:space="preserve">
+    <value>Отказано</value>
+  </data>
+  <data name="PropertiesSizeFormat" xml:space="preserve">
+    <value>{0} ({1:N0} бајтова)</value>
+  </data>
+  <data name="PropertiesApplyFailed" xml:space="preserve">
+    <value>Није могуће променити атрибуте: {0}</value>
+  </data>
+  <data name="Apply" xml:space="preserve">
+    <value>Примени</value>
+  </data>
+  <data name="Close" xml:space="preserve">
+    <value>Затвори</value>
+  </data>
 </root>

--- a/src/SmartCommander/Assets/Resources.sr-Latn-ME.resx
+++ b/src/SmartCommander/Assets/Resources.sr-Latn-ME.resx
@@ -531,4 +531,61 @@
   <data name="ChecksumCancelled" xml:space="preserve">
     <value>Izračunavanje je otkazano</value>
   </data>
+  <data name="Properties" xml:space="preserve">
+    <value>Svojstva</value>
+  </data>
+  <data name="PropertiesLocation" xml:space="preserve">
+    <value>Lokacija</value>
+  </data>
+  <data name="PropertiesType" xml:space="preserve">
+    <value>Tip</value>
+  </data>
+  <data name="PropertiesTypeFile" xml:space="preserve">
+    <value>Datoteka</value>
+  </data>
+  <data name="PropertiesTypeFolder" xml:space="preserve">
+    <value>Fascikla</value>
+  </data>
+  <data name="PropertiesContains" xml:space="preserve">
+    <value>Sadržaj</value>
+  </data>
+  <data name="PropertiesContainsFormat" xml:space="preserve">
+    <value>{0:N0} datoteka, {1:N0} fascikli</value>
+  </data>
+  <data name="PropertiesCreated" xml:space="preserve">
+    <value>Napravljeno</value>
+  </data>
+  <data name="PropertiesModified" xml:space="preserve">
+    <value>Izmijenjeno</value>
+  </data>
+  <data name="PropertiesAccessed" xml:space="preserve">
+    <value>Pristupljeno</value>
+  </data>
+  <data name="PropertiesAttributes" xml:space="preserve">
+    <value>Atributi</value>
+  </data>
+  <data name="PropertiesReadOnly" xml:space="preserve">
+    <value>Samo za čitanje</value>
+  </data>
+  <data name="PropertiesHidden" xml:space="preserve">
+    <value>Skriveno</value>
+  </data>
+  <data name="PropertiesCalculating" xml:space="preserve">
+    <value>Izračunavanje…</value>
+  </data>
+  <data name="PropertiesSizeCancelled" xml:space="preserve">
+    <value>Otkazano</value>
+  </data>
+  <data name="PropertiesSizeFormat" xml:space="preserve">
+    <value>{0} ({1:N0} bajtova)</value>
+  </data>
+  <data name="PropertiesApplyFailed" xml:space="preserve">
+    <value>Nije moguće promijeniti atribute: {0}</value>
+  </data>
+  <data name="Apply" xml:space="preserve">
+    <value>Primijeni</value>
+  </data>
+  <data name="Close" xml:space="preserve">
+    <value>Zatvori</value>
+  </data>
 </root>

--- a/src/SmartCommander/Services/PropertiesService.cs
+++ b/src/SmartCommander/Services/PropertiesService.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SmartCommander.Services
+{
+    // Snapshot of a local file/folder's metadata. Timestamps are local time.
+    public record ItemProperties(
+        string FullName,
+        bool IsFolder,
+        bool IsReadOnly,
+        bool IsHidden,
+        long Size,
+        DateTime CreationTime,
+        DateTime LastWriteTime,
+        DateTime LastAccessTime);
+
+    // Running (or final) tally of a recursive folder walk.
+    public record FolderTally(long Files, long Folders, long Bytes);
+
+    // Direct-I/O reads/writes of local file attributes and timestamps, plus a cancellable
+    // recursive folder-size walk. Not part of IFileSystemService (same exception as
+    // ArchiveService / ChecksumService). Throws on failure; callers catch and surface.
+    public class PropertiesService
+    {
+        public Task<ItemProperties> GetAsync(string path, bool isFolder)
+        {
+            return Task.Run(() => Get(path, isFolder));
+        }
+
+        private static ItemProperties Get(string path, bool isFolder)
+        {
+            FileSystemInfo info = isFolder ? new DirectoryInfo(path) : new FileInfo(path);
+            var attributes = info.Attributes;
+            long size = isFolder ? 0 : ((FileInfo)info).Length;
+            return new ItemProperties(
+                path,
+                isFolder,
+                attributes.HasFlag(FileAttributes.ReadOnly),
+                attributes.HasFlag(FileAttributes.Hidden),
+                size,
+                info.CreationTime,
+                info.LastWriteTime,
+                info.LastAccessTime);
+        }
+
+        // Applies only the two user-editable flags; every other attribute is left untouched.
+        // Hidden is a Windows-only concept here, so it is only written on Windows.
+        public Task ApplyAttributesAsync(string path, bool readOnly, bool hidden)
+        {
+            return Task.Run(() =>
+            {
+                var attributes = File.GetAttributes(path);
+                attributes = readOnly
+                    ? attributes | FileAttributes.ReadOnly
+                    : attributes & ~FileAttributes.ReadOnly;
+                if (OperatingSystem.IsWindows())
+                {
+                    attributes = hidden
+                        ? attributes | FileAttributes.Hidden
+                        : attributes & ~FileAttributes.Hidden;
+                }
+                File.SetAttributes(path, attributes);
+            });
+        }
+
+        public Task<FolderTally> ComputeFolderTallyAsync(string path, IProgress<FolderTally>? progress, CancellationToken ct)
+        {
+            return Task.Run(() => Walk(path, progress, ct), ct);
+        }
+
+        private static FolderTally Walk(string path, IProgress<FolderTally>? progress, CancellationToken ct)
+        {
+            long files = 0, folders = 0, bytes = 0;
+            var stack = new Stack<string>();
+            stack.Push(path);
+            var lastReport = DateTime.UtcNow;
+
+            while (stack.Count > 0)
+            {
+                ct.ThrowIfCancellationRequested();
+                var directory = stack.Pop();
+
+                IEnumerable<string> entries;
+                try
+                {
+                    entries = Directory.EnumerateFileSystemEntries(directory);
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    continue;
+                }
+                catch (DirectoryNotFoundException)
+                {
+                    continue;
+                }
+
+                foreach (var entry in entries)
+                {
+                    ct.ThrowIfCancellationRequested();
+                    if (Directory.Exists(entry))
+                    {
+                        folders++;
+                        // Don't descend into symlinked/junction directories - that risks a cycle.
+                        if (!new DirectoryInfo(entry).Attributes.HasFlag(FileAttributes.ReparsePoint))
+                        {
+                            stack.Push(entry);
+                        }
+                    }
+                    else
+                    {
+                        files++;
+                        try
+                        {
+                            bytes += new FileInfo(entry).Length;
+                        }
+                        catch (IOException)
+                        {
+                            // Best effort - a vanished/locked file just doesn't add to the total.
+                        }
+                    }
+
+                    var now = DateTime.UtcNow;
+                    if (progress != null && (now - lastReport).TotalMilliseconds >= 150)
+                    {
+                        progress.Report(new FolderTally(files, folders, bytes));
+                        lastReport = now;
+                    }
+                }
+            }
+
+            var result = new FolderTally(files, folders, bytes);
+            progress?.Report(result);
+            return result;
+        }
+    }
+}

--- a/src/SmartCommander/ViewModels/FilesPaneViewModel.cs
+++ b/src/SmartCommander/ViewModels/FilesPaneViewModel.cs
@@ -95,6 +95,8 @@ namespace SmartCommander.ViewModels
         // Checksum is a single-local-file tool: hidden for folders, FTP, and multi-selection.
         public bool ShowChecksum => IsRealItemSelected && !IsFtp && CurrentItem != null
             && !CurrentItem.IsFolder && CurrentItems.Count <= 1;
+        // Properties is a single local file/folder tool: hidden for FTP and multi-selection.
+        public bool ShowProperties => IsRealItemSelected && !IsFtp && CurrentItems.Count <= 1;
         public bool CanShowMoreOptions => !IsFtp && IsWindows;
         public bool CanShowItemMoreOptions => IsRealItemSelected && CanShowMoreOptions;
         // Covers both ".." and no selection at all (e.g. an empty directory) - either way
@@ -171,6 +173,7 @@ namespace SmartCommander.ViewModels
             ZipWithOptionsCommand = ReactiveCommand.CreateFromTask(ZipWithOptions);
             UnzipCommand = ReactiveCommand.CreateFromTask(Unzip);
             ChecksumCommand = ReactiveCommand.CreateFromTask(Checksum);
+            PropertiesCommand = ReactiveCommand.CreateFromTask(Properties);
             CopyCommand = ReactiveCommand.CreateFromTask(Copy);
             CutCommand = ReactiveCommand.CreateFromTask(Cut);
             TransferCommand = ReactiveCommand.CreateFromTask(() => _mainVM.Copy());
@@ -198,6 +201,7 @@ namespace SmartCommander.ViewModels
         public ReactiveCommand<Unit, Unit>? ZipWithOptionsCommand { get; }
         public ReactiveCommand<Unit, Unit>? UnzipCommand { get; }
         public ReactiveCommand<Unit, Unit>? ChecksumCommand { get; }
+        public ReactiveCommand<Unit, Unit>? PropertiesCommand { get; }
         public ReactiveCommand<Unit, Unit>? CopyCommand { get; }
         public ReactiveCommand<Unit, Unit>? CutCommand { get; }
         public ReactiveCommand<Unit, Unit>? TransferCommand { get; }
@@ -494,6 +498,11 @@ namespace SmartCommander.ViewModels
         public Task Checksum()
         {
             return _mainVM.Checksum();
+        }
+
+        public Task Properties()
+        {
+            return _mainVM.Properties();
         }
 
         public Task Delete()

--- a/src/SmartCommander/ViewModels/MainWindowViewModel.cs
+++ b/src/SmartCommander/ViewModels/MainWindowViewModel.cs
@@ -26,6 +26,7 @@ namespace SmartCommander.ViewModels
         private readonly IFileSystemService _fs;
         private readonly ArchiveService _archives = new();
         private readonly ChecksumService _checksums = new();
+        private readonly PropertiesService _properties = new();
 
         public MainWindowViewModel(IFileSystemService fs)
         {
@@ -39,6 +40,7 @@ namespace SmartCommander.ViewModels
             ShowZipOptionsDialog = new Interaction<ZipOptionsViewModel, ZipOptionsViewModel?>();
             ShowPasswordPromptDialog = new Interaction<PasswordPromptViewModel, PasswordPromptViewModel?>();
             ShowChecksumDialog = new Interaction<ChecksumViewModel, ChecksumViewModel?>();
+            ShowPropertiesDialog = new Interaction<PropertiesViewModel, PropertiesViewModel?>();
 
             ExitCommand = ReactiveCommand.Create(Exit);
             SortNameCommand = ReactiveCommand.Create(SortName);
@@ -159,6 +161,7 @@ namespace SmartCommander.ViewModels
         public Interaction<ZipOptionsViewModel, ZipOptionsViewModel?> ShowZipOptionsDialog { get; }
         public Interaction<PasswordPromptViewModel, PasswordPromptViewModel?> ShowPasswordPromptDialog { get; }
         public Interaction<ChecksumViewModel, ChecksumViewModel?> ShowChecksumDialog { get; }
+        public Interaction<PropertiesViewModel, PropertiesViewModel?> ShowPropertiesDialog { get; }
 
         public static bool IsFunctionKeysDisplayed => OptionsModel.Instance.IsFunctionKeysDisplayed;
         public static bool IsCommandLineDisplayed => OptionsModel.Instance.IsCommandLineDisplayed;
@@ -603,6 +606,19 @@ namespace SmartCommander.ViewModels
                 return;
             }
             await ShowChecksumDialog.Handle(new ChecksumViewModel(item.FullName, _checksums));
+        }
+
+        // Single local file or folder (the menu item is hidden for FTP panes and multi-selection).
+        // Self-contained dialog, no ActiveOperations entry.
+        public async Task Properties()
+        {
+            var pane = SelectedPane;
+            var item = pane.CurrentItem;
+            if (item == null || item.FullName == ".." || pane.IsFtp)
+            {
+                return;
+            }
+            await ShowPropertiesDialog.Handle(new PropertiesViewModel(item.FullName, item.IsFolder, _properties));
         }
 
         public async Task Copy()

--- a/src/SmartCommander/ViewModels/PropertiesViewModel.cs
+++ b/src/SmartCommander/ViewModels/PropertiesViewModel.cs
@@ -1,0 +1,235 @@
+using Avalonia.Controls;
+using ReactiveUI;
+using Serilog;
+using SmartCommander.Assets;
+using SmartCommander.Services;
+using System;
+using System.Globalization;
+using System.Reactive;
+using System.Threading;
+using System.Threading.Tasks;
+using Path = System.IO.Path;
+
+namespace SmartCommander.ViewModels
+{
+    // View a single local file/folder's metadata and toggle its Read-only (all platforms) and
+    // Hidden (Windows only) attributes. For a folder, the recursive size is walked off-thread
+    // and can be cancelled. No ActiveOperations entry - it's self-contained and read-mostly.
+    public class PropertiesViewModel : ViewModelBase
+    {
+        private readonly PropertiesService _service;
+        private readonly string _path;
+        private readonly bool _isFolder;
+        private readonly CancellationTokenSource _sizeCts = new();
+
+        private bool _initialReadOnly;
+        private bool _initialHidden;
+        private bool _loaded;
+
+        public PropertiesViewModel(string path, bool isFolder, PropertiesService service)
+            : this(path, isFolder, service, load: true)
+        {
+        }
+
+        // Design-time only: no file I/O.
+        public PropertiesViewModel()
+            : this(Path.Combine("C:", "folder", "file.txt"), false, new PropertiesService(), load: false)
+        {
+        }
+
+        private PropertiesViewModel(string path, bool isFolder, PropertiesService service, bool load)
+        {
+            _path = path;
+            _isFolder = isFolder;
+            _service = service;
+
+            var trimmed = path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            ItemName = Path.GetFileName(trimmed);
+            if (string.IsNullOrEmpty(ItemName))
+            {
+                ItemName = path;
+            }
+            Location = Path.GetDirectoryName(path) ?? path;
+            TypeText = isFolder ? Resources.PropertiesTypeFolder : Resources.PropertiesTypeFile;
+
+            ApplyCommand = ReactiveCommand.CreateFromTask<Window>(ApplyAsync, this.WhenAnyValue(x => x.IsDirty));
+            CancelSizeCommand = ReactiveCommand.Create(() => _sizeCts.Cancel());
+            CloseCommand = ReactiveCommand.Create<Window>(w => { _sizeCts.Cancel(); w?.Close(); });
+
+            if (load)
+            {
+                _ = LoadAsync();
+            }
+        }
+
+        public string ItemName { get; }
+        public string Location { get; }
+        public string TypeText { get; }
+        public bool IsFolder => _isFolder;
+        public bool CanEditHidden => OperatingSystem.IsWindows();
+
+        private string _sizeText = "";
+        public string SizeText { get => _sizeText; private set => this.RaiseAndSetIfChanged(ref _sizeText, value); }
+
+        private string _containsText = "";
+        public string ContainsText { get => _containsText; private set => this.RaiseAndSetIfChanged(ref _containsText, value); }
+
+        private bool _isCalculatingSize;
+        public bool IsCalculatingSize { get => _isCalculatingSize; private set => this.RaiseAndSetIfChanged(ref _isCalculatingSize, value); }
+
+        private string _created = "";
+        public string Created { get => _created; private set => this.RaiseAndSetIfChanged(ref _created, value); }
+
+        private string _modified = "";
+        public string Modified { get => _modified; private set => this.RaiseAndSetIfChanged(ref _modified, value); }
+
+        private string _accessed = "";
+        public string Accessed { get => _accessed; private set => this.RaiseAndSetIfChanged(ref _accessed, value); }
+
+        private bool _readOnly;
+        public bool ReadOnly
+        {
+            get => _readOnly;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref _readOnly, value);
+                this.RaisePropertyChanged(nameof(IsDirty));
+            }
+        }
+
+        private bool _hidden;
+        public bool Hidden
+        {
+            get => _hidden;
+            set
+            {
+                this.RaiseAndSetIfChanged(ref _hidden, value);
+                this.RaisePropertyChanged(nameof(IsDirty));
+            }
+        }
+
+        public bool IsDirty => _loaded &&
+            (_readOnly != _initialReadOnly || (CanEditHidden && _hidden != _initialHidden));
+
+        private string _status = "";
+        public string Status
+        {
+            get => _status;
+            private set
+            {
+                this.RaiseAndSetIfChanged(ref _status, value);
+                this.RaisePropertyChanged(nameof(HasStatus));
+            }
+        }
+        public bool HasStatus => !string.IsNullOrEmpty(Status);
+
+        public ReactiveCommand<Window, Unit> ApplyCommand { get; }
+        public ReactiveCommand<Unit, Unit> CancelSizeCommand { get; }
+        public ReactiveCommand<Window, Unit> CloseCommand { get; }
+
+        private async Task LoadAsync()
+        {
+            try
+            {
+                var p = await _service.GetAsync(_path, _isFolder);
+
+                _initialReadOnly = p.IsReadOnly;
+                _initialHidden = p.IsHidden;
+                _readOnly = p.IsReadOnly;
+                _hidden = p.IsHidden;
+                this.RaisePropertyChanged(nameof(ReadOnly));
+                this.RaisePropertyChanged(nameof(Hidden));
+
+                Created = p.CreationTime.ToString("G", CultureInfo.CurrentCulture);
+                Modified = p.LastWriteTime.ToString("G", CultureInfo.CurrentCulture);
+                Accessed = p.LastAccessTime.ToString("G", CultureInfo.CurrentCulture);
+
+                if (_isFolder)
+                {
+                    await ComputeSizeAsync();
+                }
+                else
+                {
+                    SizeText = FormatSize(p.Size);
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Properties load failed for {Path}", _path);
+                Status = DescribeException(ex);
+            }
+            finally
+            {
+                _loaded = true;
+                this.RaisePropertyChanged(nameof(IsDirty));
+            }
+        }
+
+        private async Task ComputeSizeAsync()
+        {
+            IsCalculatingSize = true;
+            SizeText = Resources.PropertiesCalculating;
+            try
+            {
+                var progress = new Progress<FolderTally>(t =>
+                {
+                    SizeText = FormatSize(t.Bytes);
+                    ContainsText = string.Format(Resources.PropertiesContainsFormat, t.Files, t.Folders);
+                });
+                var tally = await _service.ComputeFolderTallyAsync(_path, progress, _sizeCts.Token);
+                SizeText = FormatSize(tally.Bytes);
+                ContainsText = string.Format(Resources.PropertiesContainsFormat, tally.Files, tally.Folders);
+            }
+            catch (OperationCanceledException)
+            {
+                if (SizeText == Resources.PropertiesCalculating)
+                {
+                    SizeText = Resources.PropertiesSizeCancelled;
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Folder size walk failed for {Path}", _path);
+                Status = DescribeException(ex);
+            }
+            finally
+            {
+                IsCalculatingSize = false;
+            }
+        }
+
+        private async Task ApplyAsync(Window? window)
+        {
+            try
+            {
+                await _service.ApplyAttributesAsync(_path, _readOnly, _hidden);
+                _initialReadOnly = _readOnly;
+                _initialHidden = _hidden;
+                this.RaisePropertyChanged(nameof(IsDirty));
+                window?.Close();
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Applying attributes failed for {Path}", _path);
+                Status = string.Format(Resources.PropertiesApplyFailed, DescribeException(ex));
+            }
+        }
+
+        // "82.3 MB (86,240,133 bytes)" - human-readable value plus the exact byte count.
+        internal static string FormatSize(long bytes)
+        {
+            string[] units = { "B", "KB", "MB", "GB", "TB" };
+            double value = bytes;
+            int unit = 0;
+            while (value >= 1024 && unit < units.Length - 1)
+            {
+                value /= 1024;
+                unit++;
+            }
+            var human = unit == 0
+                ? string.Format(CultureInfo.CurrentCulture, "{0:N0} {1}", value, units[unit])
+                : string.Format(CultureInfo.CurrentCulture, "{0:N1} {1}", value, units[unit]);
+            return string.Format(Resources.PropertiesSizeFormat, human, bytes);
+        }
+    }
+}

--- a/src/SmartCommander/Views/FilesPane.axaml
+++ b/src/SmartCommander/Views/FilesPane.axaml
@@ -138,6 +138,9 @@
 					<MenuItem Header="{x:Static assets:Resources.Checksum}"
                               IsVisible="{Binding ShowChecksum}"
                               Command="{Binding ChecksumCommand}" />
+					<MenuItem Header="{x:Static assets:Resources.Properties}"
+                              IsVisible="{Binding ShowProperties}"
+                              Command="{Binding PropertiesCommand}" />
 					<MenuItem Header="{x:Static assets:Resources.MoreOptions}"
                               IsVisible="{Binding CanShowItemMoreOptions}"
                               Command="{Binding ShowMoreOptionsCommand}" />

--- a/src/SmartCommander/Views/MainWindow.axaml.cs
+++ b/src/SmartCommander/Views/MainWindow.axaml.cs
@@ -52,6 +52,9 @@ namespace SmartCommander.Views
             this.WhenActivated(d => d(ViewModel!.ShowChecksumDialog.RegisterHandler(
                 interaction => DoShowDialogAsync<ChecksumViewModel, ChecksumWindow>(interaction)
             )));
+            this.WhenActivated(d => d(ViewModel!.ShowPropertiesDialog.RegisterHandler(
+                interaction => DoShowDialogAsync<PropertiesViewModel, PropertiesWindow>(interaction)
+            )));
 
             operationsWindow = new OperationsWindow();
 

--- a/src/SmartCommander/Views/PropertiesWindow.axaml
+++ b/src/SmartCommander/Views/PropertiesWindow.axaml
@@ -1,0 +1,106 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:CompileBindings="False"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:vm="using:SmartCommander.ViewModels"
+        mc:Ignorable="d" d:DesignWidth="620" d:DesignHeight="400"
+        Width="620" SizeToContent="Height"
+        x:Class="SmartCommander.Views.PropertiesWindow"
+        WindowStartupLocation="CenterOwner"
+        ShowInTaskbar="False"
+        xmlns:assets="clr-namespace:SmartCommander.Assets"
+        Icon="/Assets/main.ico"
+        CanResize="False"
+        Title="{x:Static assets:Resources.Properties}">
+
+	<Design.DataContext>
+		<vm:PropertiesViewModel/>
+	</Design.DataContext>
+
+	<Grid Margin="15" RowDefinitions="Auto,Auto">
+		<Grid Grid.Row="0" ColumnDefinitions="Auto,*">
+			<Grid.RowDefinitions>
+				<RowDefinition Height="Auto"/>
+				<RowDefinition Height="Auto"/>
+				<RowDefinition Height="Auto"/>
+				<RowDefinition Height="Auto"/>
+				<RowDefinition Height="Auto"/>
+				<RowDefinition Height="Auto"/>
+				<RowDefinition Height="Auto"/>
+				<RowDefinition Height="Auto"/>
+				<RowDefinition Height="Auto"/>
+				<RowDefinition Height="Auto"/>
+			</Grid.RowDefinitions>
+
+			<TextBlock Grid.Row="0" Grid.Column="0" Grid.ColumnSpan="2" Margin="0,0,0,12"
+					   FontWeight="Bold" TextTrimming="CharacterEllipsis"
+					   Text="{Binding ItemName}"/>
+
+			<TextBlock Grid.Row="1" Grid.Column="0" Margin="0,0,10,8" VerticalAlignment="Center"
+					   Text="{x:Static assets:Resources.PropertiesLocation}"/>
+			<SelectableTextBlock Grid.Row="1" Grid.Column="1" Margin="0,0,0,8" VerticalAlignment="Center"
+					   TextWrapping="Wrap" Text="{Binding Location}"/>
+
+			<TextBlock Grid.Row="2" Grid.Column="0" Margin="0,0,10,8" VerticalAlignment="Center"
+					   Text="{x:Static assets:Resources.PropertiesType}"/>
+			<TextBlock Grid.Row="2" Grid.Column="1" Margin="0,0,0,8" VerticalAlignment="Center"
+					   Text="{Binding TypeText}"/>
+
+			<TextBlock Grid.Row="3" Grid.Column="0" Margin="0,0,10,8" VerticalAlignment="Center"
+					   Text="{x:Static assets:Resources.Size}"/>
+			<StackPanel Grid.Row="3" Grid.Column="1" Orientation="Horizontal" Margin="0,0,0,8">
+				<TextBlock VerticalAlignment="Center" Text="{Binding SizeText}"/>
+				<Button Margin="10,0,0,0" Padding="8,2" VerticalAlignment="Center"
+						IsVisible="{Binding IsCalculatingSize}"
+						Command="{Binding CancelSizeCommand}"
+						Content="{x:Static assets:Resources.Cancel}"/>
+			</StackPanel>
+
+			<TextBlock Grid.Row="4" Grid.Column="0" Margin="0,0,10,8" VerticalAlignment="Center"
+					   IsVisible="{Binding IsFolder}"
+					   Text="{x:Static assets:Resources.PropertiesContains}"/>
+			<TextBlock Grid.Row="4" Grid.Column="1" Margin="0,0,0,8" VerticalAlignment="Center"
+					   IsVisible="{Binding IsFolder}" Text="{Binding ContainsText}"/>
+
+			<TextBlock Grid.Row="5" Grid.Column="0" Margin="0,0,10,8" VerticalAlignment="Center"
+					   Text="{x:Static assets:Resources.PropertiesCreated}"/>
+			<TextBlock Grid.Row="5" Grid.Column="1" Margin="0,0,0,8" VerticalAlignment="Center"
+					   Text="{Binding Created}"/>
+
+			<TextBlock Grid.Row="6" Grid.Column="0" Margin="0,0,10,8" VerticalAlignment="Center"
+					   Text="{x:Static assets:Resources.PropertiesModified}"/>
+			<TextBlock Grid.Row="6" Grid.Column="1" Margin="0,0,0,8" VerticalAlignment="Center"
+					   Text="{Binding Modified}"/>
+
+			<TextBlock Grid.Row="7" Grid.Column="0" Margin="0,0,10,8" VerticalAlignment="Center"
+					   Text="{x:Static assets:Resources.PropertiesAccessed}"/>
+			<TextBlock Grid.Row="7" Grid.Column="1" Margin="0,0,0,8" VerticalAlignment="Center"
+					   Text="{Binding Accessed}"/>
+
+			<TextBlock Grid.Row="8" Grid.Column="0" Margin="0,0,10,4" VerticalAlignment="Center"
+					   Text="{x:Static assets:Resources.PropertiesAttributes}"/>
+			<StackPanel Grid.Row="8" Grid.Column="1" Orientation="Horizontal" Margin="0,0,0,4">
+				<CheckBox Margin="0,0,16,0" IsChecked="{Binding ReadOnly, Mode=TwoWay}"
+						  Content="{x:Static assets:Resources.PropertiesReadOnly}"/>
+				<CheckBox IsChecked="{Binding Hidden, Mode=TwoWay}"
+						  IsVisible="{Binding CanEditHidden}"
+						  Content="{x:Static assets:Resources.PropertiesHidden}"/>
+			</StackPanel>
+
+			<TextBlock Grid.Row="9" Grid.Column="0" Grid.ColumnSpan="2" Margin="0,8,0,0"
+					   Foreground="Gray" TextWrapping="Wrap"
+					   IsVisible="{Binding HasStatus}" Text="{Binding Status}"/>
+		</Grid>
+
+		<StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,15,0,0">
+			<Button Margin="5,0,5,0" Command="{Binding ApplyCommand}"
+					CommandParameter="{Binding $parent[Window]}"
+					Content="{x:Static assets:Resources.Apply}"/>
+			<Button Margin="5,0,0,0" Command="{Binding CloseCommand}"
+					CommandParameter="{Binding $parent[Window]}"
+					IsDefault="True" IsCancel="True"
+					Content="{x:Static assets:Resources.Close}"/>
+		</StackPanel>
+	</Grid>
+</Window>

--- a/src/SmartCommander/Views/PropertiesWindow.axaml.cs
+++ b/src/SmartCommander/Views/PropertiesWindow.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+
+namespace SmartCommander.Views
+{
+    public partial class PropertiesWindow : Window
+    {
+        public PropertiesWindow()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
The PR adds a Properties dialog for a local file or folder.

New "Properties" context-menu item (single local item only, hidden for FTP panes and multi-selection) opening a dialog that shows name, location, type, size and the created/modified/accessed timestamps, and lets the Read-only (all platforms) and Hidden (Windows) attributes be toggled. 

For a folder the recursive size and file/folder counts are walked off-thread with a Cancel
button. Backed by a new direct-I/O PropertiesService (not part of IFileSystemService, same documented exception as ArchiveService /ChecksumService).